### PR TITLE
fix!: remove unused parameter from interface.

### DIFF
--- a/lib/src/package_version/pub_api_client.dart
+++ b/lib/src/package_version/pub_api_client.dart
@@ -11,7 +11,6 @@ class PubApiClient {
   final Duration _requestTimeout;
 
   PubApiClient({
-    void Function(String error)? onError,
     http.Client? httpClient,
     requestTimeout = const Duration(seconds: 2),
   })  : _pubClient = PubClient(client: httpClient),


### PR DESCRIPTION
In a previous PR, https://github.com/serverpod/cli_tools/pull/4, we removed error handling by callbacks in the pub API client. But in the PR the interface of the constructor was never updated so an unused callback could still be passed.

This PR removes that parameter from the constructor, completing the previously started work.