### PR TITLE
feat: add input prompt component

### DIFF
--- a/lib/src/prompts/input.dart
+++ b/lib/src/prompts/input.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:cli_tools/cli_tools.dart';
+
+/// Prompts the user for input.
+/// If [defaultValue] is provided, the user can skip the prompt by pressing Enter.
+Future<String> input(
+  String message, {
+  String? defaultValue,
+  required Logger logger,
+}) async {
+  var defaultDescription = defaultValue == null ? '' : ' ($defaultValue)';
+
+  logger.write(
+    '$message$defaultDescription: ',
+    LogLevel.info,
+    newLine: false,
+    newParagraph: false,
+  );
+  var input = stdin.readLineSync()?.trim();
+  var missingInput = input == null || input.isEmpty;
+  if (missingInput) {
+    return defaultValue ?? '';
+  }
+
+  return input;
+}

--- a/test/prompts/input_test.dart
+++ b/test/prompts/input_test.dart
@@ -1,0 +1,150 @@
+import 'package:cli_tools/cli_tools.dart';
+import 'package:cli_tools/src/prompts/input.dart';
+import 'package:test/test.dart';
+
+import '../test_utils/io_helper.dart';
+
+void main() {
+  var logger = StdOutLogger(LogLevel.debug);
+
+  test(
+      'Given input prompt '
+      'when providing valid input "hello" '
+      'then should return "hello"', () async {
+    late Future<String> result;
+    await collectOutput(
+      stdinLines: ['hello'],
+      () {
+        result = input(
+          'Enter something',
+          logger: logger,
+        );
+      },
+    );
+
+    await expectLater(
+      result,
+      completion('hello'),
+    );
+  });
+
+  test(
+      'Given input prompt '
+      'when providing empty input with default value "default" '
+      'then should return "default"', () async {
+    late Future<String> result;
+    await collectOutput(
+      stdinLines: [''],
+      () async {
+        result = input(
+          'Enter something',
+          defaultValue: 'default',
+          logger: logger,
+        );
+      },
+    );
+
+    await expectLater(
+      result,
+      completion('default'),
+    );
+  });
+
+  test(
+      'Given input prompt '
+      'when providing empty input without default value '
+      'then should return an empty string', () async {
+    late Future<String> result;
+    await collectOutput(
+      stdinLines: [''],
+      () async {
+        result = input(
+          'Enter something',
+          logger: logger,
+        );
+      },
+    );
+
+    await expectLater(
+      result,
+      completion(''),
+    );
+  });
+
+  test(
+      'Given input prompt '
+      'when providing valid input "TEST" '
+      'then should return "TEST"', () async {
+    late Future<String> result;
+    await collectOutput(
+      stdinLines: ['TEST'],
+      () {
+        result = input(
+          'Enter something',
+          logger: logger,
+        );
+      },
+    );
+
+    await expectLater(
+      result,
+      completion('TEST'),
+    );
+  });
+
+  test(
+      'Given input prompt '
+      'when providing input with leading and trailing spaces '
+      'then should trim string', () async {
+    late Future<String> result;
+    await collectOutput(
+      stdinLines: ['   hello   '],
+      () async {
+        result = input(
+          'Enter something',
+          logger: logger,
+        );
+      },
+    );
+
+    await expectLater(
+      result,
+      completion('hello'),
+    );
+  });
+
+  test(
+      'Given input prompt '
+      'when providing defult value '
+      'then should display prompt with default value', () async {
+    var (:stdout, :stderr, :stdin) = await collectOutput(
+      stdinLines: [''],
+      () async {
+        await input(
+          'Enter something',
+          defaultValue: 'default',
+          logger: logger,
+        );
+      },
+    );
+
+    expect(stdout.output, 'Enter something (default): ');
+  });
+
+  test(
+      'Given input prompt '
+      'when providing no default value '
+      'then should not display a default description', () async {
+    var (:stdout, :stderr, :stdin) = await collectOutput(
+      stdinLines: ['value'],
+      () async {
+        await input(
+          'Enter something',
+          logger: logger,
+        );
+      },
+    );
+
+    expect(stdout.output, 'Enter something: ');
+  });
+}

--- a/test/prompts/input_test.dart
+++ b/test/prompts/input_test.dart
@@ -9,11 +9,11 @@ void main() {
 
   test(
       'Given input prompt '
-      'when providing valid input "hello" '
-      'then should return "hello"', () async {
+      'when providing valid input "HelloWorld" '
+      'then should return the input', () async {
     late Future<String> result;
     await collectOutput(
-      stdinLines: ['hello'],
+      stdinLines: ['HelloWorld'],
       () {
         result = input(
           'Enter something',
@@ -24,7 +24,7 @@ void main() {
 
     await expectLater(
       result,
-      completion('hello'),
+      completion('HelloWorld'),
     );
   });
 
@@ -68,27 +68,6 @@ void main() {
     await expectLater(
       result,
       completion(''),
-    );
-  });
-
-  test(
-      'Given input prompt '
-      'when providing valid input "TEST" '
-      'then should return "TEST"', () async {
-    late Future<String> result;
-    await collectOutput(
-      stdinLines: ['TEST'],
-      () {
-        result = input(
-          'Enter something',
-          logger: logger,
-        );
-      },
-    );
-
-    await expectLater(
-      result,
-      completion('TEST'),
     );
   });
 

--- a/test/prompts/key_code_sequence.dart
+++ b/test/prompts/key_code_sequence.dart
@@ -1,0 +1,4 @@
+import 'package:cli_tools/src/prompts/key_codes.dart';
+
+var arrowUpSequence = [...KeyCodes.leadingArrowEscapes, KeyCodes.arrowUp];
+var arrowDownSequence = [...KeyCodes.leadingArrowEscapes, KeyCodes.arrowDown];

--- a/test/prompts/key_code_sequence.dart
+++ b/test/prompts/key_code_sequence.dart
@@ -1,4 +1,0 @@
-import 'package:cli_tools/src/prompts/key_codes.dart';
-
-var arrowUpSequence = [...KeyCodes.leadingArrowEscapes, KeyCodes.arrowUp];
-var arrowDownSequence = [...KeyCodes.leadingArrowEscapes, KeyCodes.arrowDown];


### PR DESCRIPTION
## Description
- Adds trivial `input` prompt component:
<img width="195" alt="image" src="https://github.com/user-attachments/assets/c3c0687d-4914-4dec-8f99-b2252ba5e9dd" />

- 💡 Note: I considered adding a generic `T` value alternatively an explicit function for numbers `numberInput`. However, this is such a trivial thing to build on top for the specific use case so I kept it simple. 
