### PR TITLE
feat!: ExitException to handle full range of valid exit codes

### DIFF
--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -33,6 +33,10 @@ typedef OnAnalyticsEvent = void Function(String event);
 /// The [BetterCommandRunner] class provides a more enhanced command line interface
 /// for running commands and handling command line arguments.
 class BetterCommandRunner extends CommandRunner {
+  /// Process exit code value for command not found -
+  /// The specified command was not found or couldn't be located.
+  static const int exitCodeCommandNotFound = 127;
+
   final PassMessage? _logError;
   final PassMessage? _logInfo;
   final SetLogLevel? _setLogLevel;
@@ -115,7 +119,7 @@ class BetterCommandRunner extends CommandRunner {
     } on UsageException catch (e) {
       _onAnalyticsEvent?.call(BetterCommandRunnerAnalyticsEvents.invalid);
       _logError?.call(e.toString());
-      throw ExitException(ExitCodeType.commandNotFound);
+      throw ExitException(exitCodeCommandNotFound);
     }
   }
 
@@ -169,7 +173,7 @@ class BetterCommandRunner extends CommandRunner {
     } on UsageException catch (e) {
       _logError?.call(e.toString());
       _onAnalyticsEvent?.call(BetterCommandRunnerAnalyticsEvents.invalid);
-      throw ExitException(ExitCodeType.commandNotFound);
+      throw ExitException(exitCodeCommandNotFound);
     }
   }
 

--- a/lib/src/better_command_runner/exit_exception.dart
+++ b/lib/src/better_command_runner/exit_exception.dart
@@ -1,28 +1,21 @@
-enum ExitCodeType {
+/// An exception that can be thrown to exit the command with a specific exit code.
+class ExitException implements Exception {
+  /// Successful termination - The command was successful.
+  static const int codeOk = 0;
+
   /// General errors - This code is often used to indicate generic or
   /// unspecified errors.
-  general(1),
-
-  /// Command invoked cannot execute - The specified command was found but
-  /// couldn't be executed.
-  commandInvokedCannotExecute(126),
-
-  /// Command not found - The specified command was not found or couldn't be
-  /// located.
-  commandNotFound(127);
-
-  const ExitCodeType(this.exitCode);
-  final int exitCode;
-}
-
-/// An exception that can be thrown to exit the command with a specific exit
-class ExitException implements Exception {
-  /// Creates an instance of [ExitException].
-  ExitException([this.exitCodeType = ExitCodeType.general]);
-
-  /// The type of exit code to use.
-  final ExitCodeType exitCodeType;
+  static const int codeError = 1;
 
   /// The exit code to use.
-  int get exitCode => exitCodeType.exitCode;
+  final int exitCode;
+
+  /// Creates an instance of [ExitException] with a given exit code.
+  ExitException(this.exitCode);
+
+  /// Creates an instance of [ExitException] with an OK exit code (0).
+  ExitException.ok() : exitCode = codeOk;
+
+  /// Creates an instance of [ExitException] with a general error exit code (1).
+  ExitException.error() : exitCode = codeError;
 }

--- a/lib/src/prompts/select.dart
+++ b/lib/src/prompts/select.dart
@@ -81,7 +81,7 @@ Future<List<Option>> _interactiveSelect(
 
       var quit = keyCode == KeyCodes.q;
       if (quit) {
-        throw ExitException();
+        throw ExitException.error();
       }
 
       if (keyCode == KeyCodes.escapeSequenceStart) {

--- a/test/better_command_runner/exit_exceptions_test.dart
+++ b/test/better_command_runner/exit_exceptions_test.dart
@@ -41,7 +41,7 @@ void main() {
       await expectLater(
         () => runner.run(args),
         throwsA(predicate<ExitException>(
-            (e) => e.exitCodeType == ExitCodeType.commandNotFound)),
+            (e) => e.exitCode == BetterCommandRunner.exitCodeCommandNotFound)),
       );
     });
 
@@ -53,7 +53,7 @@ void main() {
       await expectLater(
         () => runner.run(args),
         throwsA(predicate<ExitException>(
-            (e) => e.exitCodeType == ExitCodeType.commandNotFound)),
+            (e) => e.exitCode == BetterCommandRunner.exitCodeCommandNotFound)),
       );
     });
 
@@ -65,7 +65,7 @@ void main() {
       await expectLater(
         () => runner.run(args),
         throwsA(predicate<ExitException>(
-            (e) => e.exitCodeType == ExitCodeType.commandNotFound)),
+            (e) => e.exitCode == BetterCommandRunner.exitCodeCommandNotFound)),
       );
     });
   });


### PR DESCRIPTION
Makes ExitException open-ended regarding the exit code values used by applications.

Removes the ExitCodeType enum since that hindered applications from using other than the predefined values.

This is a breaking change.