### PR TITLE
feat!: Log all to stdout by default

### DIFF
--- a/lib/src/logger/loggers/std_out_logger.dart
+++ b/lib/src/logger/loggers/std_out_logger.dart
@@ -14,10 +14,23 @@ class StdOutLogger extends Logger {
 
   Progress? trackedAnimationInProgress;
 
+  /// [logToStderrLevelThreshold] is the log level threshold at which messages
+  /// are written to [stderr] instead of [stdout].
+  /// If null (the default), messages are written to [stdout] for all log levels.
+  final LogLevel? logToStderrLevelThreshold;
+
   final Map<String, String>? _replacements;
 
-  StdOutLogger(super.logLevel, {Map<String, String>? replacements})
-      : _replacements = replacements;
+  /// Creates a new [StdOutLogger].
+  ///
+  /// [logToStderrLevelThreshold] is the log level threshold at which messages
+  /// are written to [stderr] instead of [stdout].
+  /// If null (the default), messages are written to [stdout] for all log levels.
+  StdOutLogger(
+    super.logLevel, {
+    Map<String, String>? replacements,
+    this.logToStderrLevelThreshold,
+  }) : _replacements = replacements;
 
   @override
   int? get wrapTextColumn => stdout.hasTerminal ? stdout.terminalColumns : null;
@@ -195,10 +208,12 @@ class StdOutLogger extends Logger {
     };
 
     _stopAnimationInProgress();
-    if (logLevel.index >= LogLevel.warning.index) {
-      stderr.write('${newParagraph ? '\n' : ''}$message${newLine ? '\n' : ''}');
+    var output = '${newParagraph ? '\n' : ''}$message${newLine ? '\n' : ''}';
+    var threshold = logToStderrLevelThreshold;
+    if (threshold != null && logLevel.index >= threshold.index) {
+      stderr.write(output);
     } else {
-      stdout.write('${newParagraph ? '\n' : ''}$message${newLine ? '\n' : ''}');
+      stdout.write(output);
     }
   }
 

--- a/test/std_out_logger_test.dart
+++ b/test/std_out_logger_test.dart
@@ -1,0 +1,97 @@
+import 'package:cli_tools/cli_tools.dart';
+import 'package:test/test.dart';
+
+import 'test_utils/io_helper.dart';
+
+void main() {
+  group('Given a StdOutLogger with default settings', () {
+    var logger = StdOutLogger(LogLevel.debug);
+
+    test(
+        'when logging debug message '
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.debug('debug message'),
+      );
+      expect(stdout.output, 'DEBUG: debug message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging info message '
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.info('info message'),
+      );
+      expect(stdout.output, 'info message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging warning message '
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.warning('warning message'),
+      );
+      expect(stdout.output, 'WARNING: warning message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging error message '
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.error('error message'),
+      );
+      expect(stdout.output, 'ERROR: error message\n');
+      expect(stderr.output, '');
+    });
+  });
+
+  group('Given a StdOutLogger with warning log-to-stderr threshold', () {
+    var logger = StdOutLogger(
+      LogLevel.debug,
+      logToStderrLevelThreshold: LogLevel.warning,
+    );
+
+    test(
+        'when logging debug message '
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.debug('debug message'),
+      );
+      expect(stdout.output, 'DEBUG: debug message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging info message '
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.info('info message'),
+      );
+      expect(stdout.output, 'info message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging warning message '
+        'then log output is written to stderr and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.warning('warning message'),
+      );
+      expect(stdout.output, '');
+      expect(stderr.output, 'WARNING: warning message\n');
+    });
+
+    test(
+        'when logging error message '
+        'then log output is written to stderr and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.error('error message'),
+      );
+      expect(stdout.output, '');
+      expect(stderr.output, 'ERROR: error message\n');
+    });
+  });
+}


### PR DESCRIPTION
BREAKING CHANGE
Previously the logger wrote warnings and errors to stderr. Now it writes all output to stdout by default, and there is a constructor parameter to set a log level threshold for sending output to stderr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging functionality with a configurable threshold, allowing the system to route messages based on severity for improved output management.
- **Tests**
	- Added comprehensive tests verifying that messages are sent to the appropriate output stream under different configurations, ensuring consistent logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->