### PR TITLE
ci: Add job to deploy to pub.dev

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,12 @@
+name: Publish CLI Tools
+
+on:
+    push:
+        tags:
+            - 'v[0-9]+.[0-9]+.[0-9]+*' # Matches tags like v1.2.3 and v1.2.3-pre.1
+
+jobs:
+    publish:
+        permissions:
+            id-token: write
+        uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,13 @@
+# How to publish CLI Tools
+
+To publish this package, simply create a new tag and push it to the repository. The GitHub action will automatically build and publish the package to pub.dev.
+
+The tag needs to be in the format `vX.Y.Z`, where `X`, `Y`, and `Z` are integers. The version number should be incremented according to the [Semantic Versioning](https://semver.org/) rules.
+
+It is also possible to publish a pre-release version by adding a suffix to the version number. For example, `v1.0.0-dev.1` is a pre-release version of `v1.0.0`.
+
+## Create a new tag
+
+The preferred way to create a new tag is to use GitHubs interface to create a new release.
+
+The automatically generated changelogs for the github release do not need to be modified. Instead the `CHANGELOG.md` is our source of truth on pub.dev.

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -8,6 +8,6 @@ It is also possible to publish a pre-release version by adding a suffix to the v
 
 ## Create a new tag
 
-The preferred way to create a new tag is to use GitHubs interface to create a new release.
+The preferred way to create a new tag is to use GitHub's interface to create a new release.
 
-The automatically generated changelogs for the github release do not need to be modified. Instead the `CHANGELOG.md` is our source of truth on pub.dev.
+The automatically generated changelogs for the github release do not need to be modified. Instead, the `CHANGELOG.md` is our source of truth on pub.dev.


### PR DESCRIPTION
Enable CI job for deploying to pub.dev when a release tag is created.

The tag needs to start with `v` followed by a semver number and then optionally followed by any character. For example, `v1.2.3` or `v1.2.3-pre.1`

Follows the guide here: https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pub-dev

### Note on regex

Seems like Github uses the glob pattern but treats some characters different (*, **, +, ?, ! ) meaning that `.` does not need to be escaped but will be treated as a single dot.

Tested patterns listed above in a different repo:

![Screenshot 2025-02-28 at 08 21 52](https://github.com/user-attachments/assets/a3d365ce-2413-4ee2-b52f-b9c602bcf950)


Source: 
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated publishing process for CLI tools triggered by new version tags, streamlining the deployment of updates.
  - Added a `PUBLISH.md` file with guidelines for publishing CLI tools, including versioning and tagging instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->