### PR TITLE
ci: Add PR title validator

### DIFF
--- a/.github/workflows/title-validation.yaml
+++ b/.github/workflows/title-validation.yaml
@@ -1,0 +1,34 @@
+# See https://github.com/amannn/action-semantic-pull-request
+name: 'PR Title is Conventional'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          subjectPattern: ^[A-Z].+$
+          subjectPatternError: |
+            The subject of the PR must begin with an uppercase letter.


### PR DESCRIPTION
Adds a PR title validator inspired by the configuration for the flame open source repository: https://github.com/flame-engine/flame/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml?plain=1

Since PR titles are by default used as the commit message to main, this linter will help us ensure we follow conventional commits for the squashes in main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced an automated system to validate contribution titles. This ensures that titles follow a standardized, semantic format (including starting with an uppercase letter) for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->