### PR TITLE
refactor!: Clarified BetterCommandRunner output/logger setup

### DIFF
--- a/lib/src/better_command_runner/better_command.dart
+++ b/lib/src/better_command_runner/better_command.dart
@@ -3,11 +3,11 @@ import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
 
 abstract class BetterCommand extends Command {
-  final PassMessage? _logInfo;
+  final PassOutput? _passOutput;
   final ArgParser _argParser;
 
-  BetterCommand({PassMessage? logInfo, int? wrapTextColumn})
-      : _logInfo = logInfo,
+  BetterCommand({PassOutput? passOutput, int? wrapTextColumn})
+      : _passOutput = passOutput,
         _argParser = ArgParser(usageLineLength: wrapTextColumn);
 
   @override
@@ -15,6 +15,6 @@ abstract class BetterCommand extends Command {
 
   @override
   void printUsage() {
-    _logInfo?.call(usage);
+    _passOutput?.logUsage(usage);
   }
 }

--- a/test/better_command_runner/logging_test.dart
+++ b/test/better_command_runner/logging_test.dart
@@ -33,8 +33,10 @@ void main() {
     var runner = BetterCommandRunner(
       'test',
       'this is a test cli',
-      logError: (message) => errors.add(message),
-      logInfo: (message) => infos.add(message),
+      passOutput: PassOutputFuncs(
+        logUsageException: (e) => errors.add(e.toString()),
+        logUsage: (u) => infos.add(u),
+      ),
     )..addCommand(MockCommand());
     tearDown(() {
       errors.clear();

--- a/test/better_command_test.dart
+++ b/test/better_command_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 class MockCommand extends BetterCommand {
   static String commandName = 'mock-command';
 
-  MockCommand({super.logInfo}) {
+  MockCommand({super.passOutput}) {
     argParser.addOption(
       'name',
       defaultsTo: 'serverpod',
@@ -26,7 +26,9 @@ void main() {
   group('Given a better command registered in the better command runner', () {
     var infos = <String>[];
     var betterCommand = MockCommand(
-      logInfo: (String message) => infos.add(message),
+      passOutput: PassOutputFuncs(
+        logUsage: (u) => infos.add(u),
+      ),
     );
     var runner = BetterCommandRunner('test', 'test project')
       ..addCommand(betterCommand);


### PR DESCRIPTION
In order to make it more clear what output behavior is being configured, `BetterCommandRunner`'s constructor parameters were changed from:

```dart
    PassMessage? logError,
    PassMessage? logInfo,
```

to:

```dart
    PassOutput? passOutput,
```

PassOutput is a new interface containing specific output members:

```dart
abstract interface class PassOutput {
  void logUsageException(UsageException exception);

  void logUsage(String usage);
}
```