### PR TITLE
fix!: Previously missed renaming of messageOutput

### DIFF
--- a/lib/src/better_command_runner/better_command.dart
+++ b/lib/src/better_command_runner/better_command.dart
@@ -3,11 +3,11 @@ import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
 
 abstract class BetterCommand extends Command {
-  final MessageOutput? _passOutput;
+  final MessageOutput? _messageOutput;
   final ArgParser _argParser;
 
-  BetterCommand({MessageOutput? passOutput, int? wrapTextColumn})
-      : _passOutput = passOutput,
+  BetterCommand({MessageOutput? messageOutput, int? wrapTextColumn})
+      : _messageOutput = messageOutput,
         _argParser = ArgParser(usageLineLength: wrapTextColumn);
 
   @override
@@ -15,6 +15,6 @@ abstract class BetterCommand extends Command {
 
   @override
   void printUsage() {
-    _passOutput?.logUsage(usage);
+    _messageOutput?.logUsage(usage);
   }
 }

--- a/lib/src/prompts/prompts.dart
+++ b/lib/src/prompts/prompts.dart
@@ -1,2 +1,3 @@
 export 'confirm.dart';
+export 'input.dart';
 export 'select.dart' hide underline;

--- a/test/better_command_test.dart
+++ b/test/better_command_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 class MockCommand extends BetterCommand {
   static String commandName = 'mock-command';
 
-  MockCommand({super.passOutput}) {
+  MockCommand({super.messageOutput}) {
     argParser.addOption(
       'name',
       defaultsTo: 'serverpod',
@@ -26,7 +26,7 @@ void main() {
   group('Given a better command registered in the better command runner', () {
     var infos = <String>[];
     var betterCommand = MockCommand(
-      passOutput: MessageOutput(
+      messageOutput: MessageOutput(
         logUsage: (u) => infos.add(u),
       ),
     );

--- a/test/prompts/input_test.dart
+++ b/test/prompts/input_test.dart
@@ -1,5 +1,4 @@
 import 'package:cli_tools/cli_tools.dart';
-import 'package:cli_tools/src/prompts/input.dart';
 import 'package:test/test.dart';
 
 import '../test_utils/io_helper.dart';


### PR DESCRIPTION
Fixes:

In our previous version bump to 0.4.0 we missed renaming the `BetterCommand` constructor parameter to messageOutput (it should be the same name as in `BetterCommandRunner`). This is technically a breaking change.

`input.dart` was previously omitted from the `promts.dart` exports file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated parameter naming in command-related classes and tests for improved clarity and consistency.
- **New Features**
  - Made additional input functionality available by exporting input features from prompts.
- **Tests**
  - Adjusted test code to align with updated parameter names and removed an unnecessary import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->