### PR TITLE
fix: Fixes and updates based on learnings from serverpod cli

### DIFF
--- a/lib/src/better_command_runner/better_command.dart
+++ b/lib/src/better_command_runner/better_command.dart
@@ -17,6 +17,35 @@ abstract class BetterCommand<O extends OptionDefinition, T> extends Command<T> {
   /// The option definitions for this command.
   final List<O> options;
 
+  /// Creates a new instance of [BetterCommand].
+  ///
+  /// - [messageOutput] is an optional [MessageOutput] object used to pass specific log messages.
+  /// - [wrapTextColumn] is the column width for wrapping text in the command line interface.
+  /// - [options] is an optional list of options.
+  /// - [configResolver] is an optional custom [ConfigResolver] implementation.
+  ///
+  /// To define a bespoke set of options, it is recommended to define
+  /// a proper options enum. It can included any of the default options
+  /// as well as any custom options. Example:
+  ///
+  /// ```dart
+  /// enum BespokeOption<V> implements OptionDefinition<V> {
+  ///   name(StringOption(
+  ///     argName: 'name',
+  ///     allowedValues: ['serverpod', 'stockholm'],
+  ///     defaultsTo: 'serverpod',
+  ///   )),
+  ///   age(IntOption(argName: 'age', helpText: 'Required age', min: 0, max: 100));
+  ///
+  ///   const BespokeOption(this.option);
+  ///
+  ///   @override
+  ///   final ConfigOptionBase<V> option;
+  /// }
+  /// ```
+  ///
+  /// If [configResolver] is not provided then [DefaultConfigResolver] will be used,
+  /// which uses the command line arguments and environment variables as input sources.
   BetterCommand({
     MessageOutput? messageOutput,
     int? wrapTextColumn,

--- a/lib/src/config/configuration.dart
+++ b/lib/src/config/configuration.dart
@@ -83,6 +83,11 @@ abstract class ValueParser<V> {
 /// The subclasses implement specific option value types,
 /// e.g. [StringOption], [FlagOption] (boolean), [IntOption], etc.
 ///
+/// A [customValidator] may be provided for an individual option.
+/// If a value was provided the customValidator is invoked,
+/// and shall throw a [FormatException] if its format is invalid,
+/// or a [UsageException] if the it is invalid for other reasons.
+///
 /// ### Positional arguments
 ///
 /// If multiple positional arguments are defined,
@@ -163,7 +168,9 @@ class ConfigOptionBase<V> implements OptionDefinition<V> {
   }
 
   String? defaultValueString() {
-    return defaultValue()?.toString();
+    final defValue = defaultValue();
+    if (defValue == null) return null;
+    return valueParser.format(defValue);
   }
 
   String? valueHelpString() {
@@ -525,8 +532,8 @@ class MultiParser<T> extends ValueParser<List<T>> {
   final Pattern? separator;
   final String joiner;
 
-  const MultiParser({
-    required this.elementParser,
+  const MultiParser(
+    this.elementParser, {
     this.separator = ',',
     this.joiner = ',',
   });

--- a/lib/src/logger/logger.dart
+++ b/lib/src/logger/logger.dart
@@ -35,6 +35,16 @@ abstract class Logger {
     LogType type,
   });
 
+  /// Display a [message] to the user with a specified [level].
+  ///
+  /// This is for logging messages with a dynamically specified log level.
+  void log(
+    String message,
+    LogLevel level, {
+    bool newParagraph,
+    LogType type,
+  });
+
   /// Display a progress message on [LogLevel.info] while running [runner]
   /// function.
   ///

--- a/lib/src/logger/loggers/void_logger.dart
+++ b/lib/src/logger/loggers/void_logger.dart
@@ -39,6 +39,14 @@ class VoidLogger extends Logger {
   }) {}
 
   @override
+  void log(
+    String message,
+    LogLevel level, {
+    bool newParagraph = false,
+    LogType type = const RawLogType(),
+  }) {}
+
+  @override
   Future<void> flush() {
     return Future(() => {});
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   args: ^2.7.0
   ci: ^0.1.0
-  collection: ^1.19.1
+  collection: ^1.18.0
   http: '>=0.13.0 <2.0.0'
   meta: ^1.16.0
   path: ^1.8.2

--- a/test/config/configuration_type_test.dart
+++ b/test/config/configuration_type_test.dart
@@ -286,7 +286,7 @@ void main() async {
 
   group('Given a MultiOption of strings', () {
     const typedOpt = MultiOption(
-      multiParser: MultiParser(elementParser: StringParser()),
+      multiParser: MultiParser(StringParser()),
       argName: 'many',
       envName: 'SERVERPOD_MANY',
       configKey: 'many',
@@ -433,7 +433,7 @@ void main() async {
 
   group('Given a MultiOption of integers without default value', () {
     const typedOpt = MultiOption(
-      multiParser: MultiParser(elementParser: IntParser()),
+      multiParser: MultiParser(IntParser()),
       argName: 'many',
       envName: 'SERVERPOD_MANY',
       configKey: 'many',
@@ -590,7 +590,7 @@ void main() async {
 
   group('Given a MultiOption of integers with default value', () {
     const typedOpt = MultiOption(
-      multiParser: MultiParser(elementParser: IntParser()),
+      multiParser: MultiParser(IntParser()),
       argName: 'many',
       envName: 'SERVERPOD_MANY',
       configKey: 'many',
@@ -669,7 +669,7 @@ void main() async {
 
   group('Given a mandatory MultiOption of integers with alias', () {
     const typedOpt = MultiOption(
-      multiParser: MultiParser(elementParser: IntParser()),
+      multiParser: MultiParser(IntParser()),
       argName: 'many',
       argAliases: ['alias-many'],
       envName: 'SERVERPOD_MANY',

--- a/test/std_out_logger_test.dart
+++ b/test/std_out_logger_test.dart
@@ -38,6 +38,46 @@ void main() {
     });
 
     test(
+        'when logging error message via log method'
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.log('error message', LogLevel.error),
+      );
+      expect(stdout.output, 'ERROR: error message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging debug message via log method'
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.log('debug message', LogLevel.debug),
+      );
+      expect(stdout.output, 'DEBUG: debug message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging info message via log method'
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.log('info message', LogLevel.info),
+      );
+      expect(stdout.output, 'info message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging warning message via log method'
+        'then log output is written to stdout and correct', () async {
+      var (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.log('warning message', LogLevel.warning),
+      );
+      expect(stdout.output, 'WARNING: warning message\n');
+      expect(stderr.output, '');
+    });
+
+    test(
         'when logging error message '
         'then log output is written to stdout and correct', () async {
       var (:stdout, :stderr, :stdin) = await collectOutput(


### PR DESCRIPTION
Some fixes and updates based on learnings from migrating the serverpod command to cli_tools `0.5.0-beta.1`:

- New `Logger.log` method with dynamically specified log level
- Downgrades `collection` dependency to 1.18 to be compatible with serverpod
- Fixes some usage help composition
- Minor API improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved and extended documentation for configuration options, enums, and constructors, including usage examples and clearer parameter explanations.

- **New Features**
  - Added the ability to externally set the global configuration before running commands.

- **Bug Fixes**
  - Improved formatting and help string generation for enum and multi-value options.

- **Refactor**
  - Simplified parser and option constructors for easier usage and consistency.
  - Shifted configuration resolution to parsing phase for streamlined command execution.

- **Chores**
  - Updated dependency constraints for better compatibility.
  - Updated tests to match constructor changes without altering test logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->