### PR TITLE
ci: Run with Dart 3.3 and 3.6 in CI pipeline tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,30 +11,39 @@ on:
 jobs:
     dart_format:
         name: Dart format
+        strategy:
+            matrix:
+                dart: [3.3, 3.6]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: dart-lang/setup-dart@v1.7.1
               with:
-                sdk: 3.6
+                sdk: ${{ matrix.dart }}
             - name: Verify formatting
               run: dart format --output=none --set-exit-if-changed .
     dart_analyze:
         name: Dart Analyze
+        strategy:
+            matrix:
+                dart: [3.3, 3.6]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: dart-lang/setup-dart@v1.7.1
               with:
-                sdk: 3.6
+                sdk: ${{ matrix.dart }}
             - run: dart pub get
             - run: dart analyze --fatal-infos
     dart_test:
         name: Dart Test
+        strategy:
+            matrix:
+                dart: [3.3, 3.6]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: dart-lang/setup-dart@v1.7.1
               with:
-                sdk: 3.6
+                sdk: ${{ matrix.dart }}
             - run: dart test

--- a/lib/src/config/configuration.dart
+++ b/lib/src/config/configuration.dart
@@ -338,7 +338,7 @@ class ConfigOptionBase<V> implements OptionDefinition<V> {
     result = _resolveDefaultValue();
     if (result != null) return result;
 
-    return OptionResolution.noValue();
+    return const OptionResolution.noValue();
   }
 
   OptionResolution<V>? _resolveNamedArg(final ArgResults? args) {

--- a/test/prompts/confirm_test.dart
+++ b/test/prompts/confirm_test.dart
@@ -1,3 +1,6 @@
+// ignore required for Dart 3.3
+// ignore_for_file: unused_local_variable
+
 import 'package:cli_tools/cli_tools.dart';
 import 'package:test/test.dart';
 

--- a/test/prompts/input_test.dart
+++ b/test/prompts/input_test.dart
@@ -1,3 +1,6 @@
+// ignore required for Dart 3.3
+// ignore_for_file: unused_local_variable
+
 import 'package:cli_tools/cli_tools.dart';
 import 'package:test/test.dart';
 

--- a/test/prompts/multiple_select_test.dart
+++ b/test/prompts/multiple_select_test.dart
@@ -1,3 +1,6 @@
+// ignore required for Dart 3.3
+// ignore_for_file: unused_local_variable
+
 import 'package:cli_tools/cli_tools.dart';
 import 'package:cli_tools/src/prompts/key_codes.dart';
 import 'package:cli_tools/src/prompts/select.dart';

--- a/test/prompts/select_test.dart
+++ b/test/prompts/select_test.dart
@@ -1,3 +1,6 @@
+// ignore required for Dart 3.3
+// ignore_for_file: unused_local_variable
+
 import 'package:cli_tools/cli_tools.dart';
 import 'package:cli_tools/src/prompts/key_codes.dart';
 import 'package:cli_tools/src/prompts/select.dart';

--- a/test/std_out_logger_test.dart
+++ b/test/std_out_logger_test.dart
@@ -1,3 +1,6 @@
+// ignore required for Dart 3.3
+// ignore_for_file: unused_local_variable
+
 import 'package:cli_tools/cli_tools.dart';
 import 'package:test/test.dart';
 

--- a/test/test_utils/mock_stdout.dart
+++ b/test/test_utils/mock_stdout.dart
@@ -8,6 +8,8 @@ class MockStdout implements Stdout {
   Encoding encoding = utf8;
 
   @override
+  // ignore required for Dart 3.3
+  // ignore: override_on_non_overriding_member
   String lineTerminator = '\n';
 
   String get output => _buffer.toString();


### PR DESCRIPTION
This package specifies Dart SDK dependency of 3.3 or greater, but did not test it with Dart 3.3 in the CI pipeline. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated continuous integration workflow to test against multiple Dart SDK versions (3.3 and 3.6) for improved compatibility.
- **Style**
	- Added analyzer directives to test files to suppress warnings and lint errors related to Dart 3.3 and unused variables.
- **Refactor**
	- Optimized internal handling of configuration resolution for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->