### PR TITLE
chore: Bump version to 0.5.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0-beta.4
+
+- fix!: Clarified behavior of mutually exclusive option groups
+
 ## 0.5.0-beta.3
 
 - fix: Replaced yaml_codec dependency with yaml in order to support Dart 3.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.5.0-beta.3
+version: 0.5.0-beta.4
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a changelog entry for version 0.5.0-beta.4, highlighting a breaking fix related to mutually exclusive option groups.

- **Chores**
  - Updated the package version to 0.5.0-beta.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->