### PR TITLE
refactor: Simplified default usage of BetterCommand/Runner

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -8,7 +8,7 @@ import 'package:cli_tools/config.dart';
 void main(List<String> args) async {
   var commandRunner = BetterCommandRunner(
     'example',
-    'Example CLI commmand',
+    'Example CLI command',
     globalOptions: [
       StandardGlobalOption.quiet,
       StandardGlobalOption.verbose,
@@ -108,6 +108,9 @@ class TimeSeriesCommand extends BetterCommand<TimeSeriesOption, void> {
     var length = commandConfig.optionalValue(TimeSeriesOption.length);
     var interval = commandConfig.optionalValue(TimeSeriesOption.interval);
     interval ??= (until.difference(start) ~/ length!);
+    if (interval < const Duration(milliseconds: 1)) {
+      interval = const Duration(milliseconds: 1);
+    }
 
     while (start.isBefore(until)) {
       print(start);

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,16 +1,117 @@
-import 'package:cli_tools/cli_tools.dart';
+import 'dart:async' show FutureOr;
+import 'dart:io' show exit;
 
-void main() async {
+import 'package:args/command_runner.dart';
+import 'package:cli_tools/cli_tools.dart';
+import 'package:cli_tools/config.dart';
+
+void main(List<String> args) async {
+  var commandRunner = BetterCommandRunner(
+    'example',
+    'Example CLI commmand',
+    globalOptions: [
+      StandardGlobalOption.quiet,
+      StandardGlobalOption.verbose,
+    ],
+  );
+  commandRunner.addCommand(TimeSeriesCommand());
+
+  try {
+    await commandRunner.run(args);
+  } on UsageException catch (e) {
+    print(e);
+    exit(1);
+  }
+
   /// Simple example of using the [StdOutLogger] class.
-  var logger = StdOutLogger(LogLevel.info);
+  final LogLevel logLevel;
+  if (commandRunner.globalConfiguration.value(StandardGlobalOption.verbose)) {
+    logLevel = LogLevel.debug;
+  } else if (commandRunner.globalConfiguration
+      .value(StandardGlobalOption.quiet)) {
+    logLevel = LogLevel.error;
+  } else {
+    logLevel = LogLevel.info;
+  }
+  var logger = StdOutLogger(logLevel);
 
   logger.info('An info message');
   logger.error('An error message');
   logger.debug(
-    'A debug message that will not be shown because log level is info',
+    'A debug message that will not be shown unless --verbose is set',
   );
   await logger.progress(
     'A progress message',
     () async => Future.delayed(const Duration(seconds: 3), () => true),
   );
+}
+
+/// Options are defineable as enums as well as regular lists.
+///
+/// The enum approach is more distinct and type safe.
+/// The list approach is more dynamic and permits non-const initialization.
+enum TimeSeriesOption<V> implements OptionDefinition<V> {
+  until(DateTimeOption(
+    argName: 'until',
+    envName: 'SERIES_UNTIL', // can also be specified as environment variable
+    fromDefault: _defaultUntil,
+    helpText: 'The end timestamp of the series',
+  )),
+  length(IntOption(
+    argName: 'length',
+    argAbbrev: 'l',
+    argPos: 0, // can also be specified as positional argument
+    helpText: 'The number of elements in the series',
+    min: 1,
+    max: 100,
+    group: _granularityGroup,
+  )),
+  interval(DurationOption(
+    argName: 'interval',
+    argAbbrev: 'i',
+    helpText: 'The interval between the series elements',
+    min: Duration(seconds: 1),
+    max: Duration(days: 1),
+    group: _granularityGroup,
+  ));
+
+  const TimeSeriesOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+}
+
+/// Exactly one of the options in this group must be set.
+const _granularityGroup = MutuallyExclusive(
+  'Granularity',
+  mode: MutuallyExclusiveMode.mandatory,
+);
+
+/// A function can be used as a const initializer.
+DateTime _defaultUntil() => DateTime.now().add(const Duration(days: 1));
+
+class TimeSeriesCommand extends BetterCommand<TimeSeriesOption, void> {
+  TimeSeriesCommand() : super(options: TimeSeriesOption.values);
+
+  @override
+  String get name => 'series';
+
+  @override
+  String get description => 'Generate a series of time stamps';
+
+  @override
+  FutureOr<void>? runWithConfig(Configuration<TimeSeriesOption> commandConfig) {
+    var start = DateTime.now();
+    var until = commandConfig.value(TimeSeriesOption.until);
+
+    // exactly one of these options is set
+    var length = commandConfig.optionalValue(TimeSeriesOption.length);
+    var interval = commandConfig.optionalValue(TimeSeriesOption.interval);
+    interval ??= (until.difference(start) ~/ length!);
+
+    while (start.isBefore(until)) {
+      print(start);
+      start = start.add(interval);
+    }
+  }
 }

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -164,11 +164,11 @@ class BetterCommandRunner<O extends OptionDefinition, T>
     if (globalOptions != null) {
       _globalOptions = globalOptions;
     } else if (_onAnalyticsEvent != null) {
-      _globalOptions = BasicGlobalOption.values as List<O>;
+      _globalOptions = StandardGlobalOption.values as List<O>;
     } else {
       _globalOptions = [
-        BasicGlobalOption.quiet as O,
-        BasicGlobalOption.verbose as O,
+        StandardGlobalOption.quiet as O,
+        StandardGlobalOption.verbose as O,
       ];
     }
     prepareOptionsForParsing(_globalOptions, argParser);
@@ -344,12 +344,12 @@ abstract class BetterCommandRunnerFlags {
   );
 }
 
-enum BasicGlobalOption<V> implements OptionDefinition<V> {
+enum StandardGlobalOption<V> implements OptionDefinition<V> {
   quiet(BetterCommandRunnerFlags.quietOption),
   verbose(BetterCommandRunnerFlags.verboseOption),
   analytics(BetterCommandRunnerFlags.analyticsOption);
 
-  const BasicGlobalOption(this.option);
+  const StandardGlobalOption(this.option);
 
   @override
   final ConfigOptionBase<V> option;

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -72,7 +72,6 @@ class BetterCommandRunner<O extends OptionDefinition, T>
   /// The gloabl option definitions.
   late final List<O> _globalOptions;
 
-  /// The resolver for the global configuration.
   final ConfigResolver<O> _configResolver;
 
   Configuration<O>? _globalConfiguration;
@@ -174,6 +173,14 @@ class BetterCommandRunner<O extends OptionDefinition, T>
     prepareOptionsForParsing(_globalOptions, argParser);
   }
 
+  /// The [MessageOutput] for the command runner.
+  /// It is also used for the commands unless they have their own.
+  MessageOutput? get messageOutput => _messageOutput;
+
+  /// The configuration resolver used for the global configuration.
+  /// It is also used for the command configurations unless they have their own.
+  ConfigResolver<O> get configResolver => _configResolver;
+
   /// Adds a list of commands to the command runner.
   void addCommands(List<Command<T>> commands) {
     for (var command in commands) {
@@ -208,7 +215,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
     try {
       return super.parse(args);
     } on UsageException catch (e) {
-      _messageOutput?.logUsageException(e);
+      messageOutput?.logUsageException(e);
       _onAnalyticsEvent?.call(BetterCommandRunnerAnalyticsEvents.invalid);
       rethrow;
     }
@@ -216,7 +223,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
 
   @override
   void printUsage() {
-    _messageOutput?.logUsage(usage);
+    messageOutput?.logUsage(usage);
   }
 
   /// Runs the command specified by [topLevelResults].
@@ -277,7 +284,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
     try {
       return await super.runCommand(topLevelResults);
     } on UsageException catch (e) {
-      _messageOutput?.logUsageException(e);
+      messageOutput?.logUsageException(e);
       _onAnalyticsEvent?.call(BetterCommandRunnerAnalyticsEvents.invalid);
       rethrow;
     }

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -301,6 +301,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
     final config = _configResolver.resolveConfiguration(
       options: _globalOptions,
       argResults: argResults,
+      ignoreUnexpectedPositionalArgs: true,
     );
 
     if (config.errors.isNotEmpty) {

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -12,26 +12,24 @@ typedef OnBeforeRunCommand = Future<void> Function(BetterCommandRunner runner);
 ///
 /// It is valid to not provide a function in order to not pass that output.
 final class MessageOutput {
-  final void Function(UsageException exception)? _logUsageException;
+  final void Function(String usage)? usageLogger;
+  final void Function(UsageException exception)? usageExceptionLogger;
 
-  final void Function(String usage)? _logUsage;
-
-  MessageOutput({
-    void Function(UsageException exception)? logUsageException,
-    void Function(String usage)? logUsage,
-  })  : _logUsageException = logUsageException,
-        _logUsage = logUsage;
+  const MessageOutput({
+    this.usageLogger,
+    this.usageExceptionLogger,
+  });
 
   /// Logs a usage exception.
   /// If the function has not been provided then nothing will happen.
   void logUsageException(UsageException exception) {
-    _logUsageException?.call(exception);
+    usageExceptionLogger?.call(exception);
   }
 
   /// Logs a usage message.
   /// If the function has not been provided then nothing will happen.
   void logUsage(String usage) {
-    _logUsage?.call(usage);
+    usageLogger?.call(usage);
   }
 }
 
@@ -106,6 +104,16 @@ class BetterCommandRunner<O extends OptionDefinition, T>
   /// - [globalOptions] is an optional list of global options.
   /// - [configResolver] is an optional custom [ConfigResolver] implementation.
   ///
+  /// ## Message Output
+  ///
+  /// The [MessageOutput] object is used to control how specific log messages
+  /// are output within this library.
+  /// By default regular (non-error) usage is printed to the console,
+  /// while UsageExceptions not printed by this library and simply
+  /// propagated to the caller, i.e. the same behavior as the `args` package.
+  ///
+  /// ## Global Options
+  ///
   /// If [globalOptions] is not provided then the default global options will be used.
   /// If no global options are desired then an empty list can be provided.
   ///
@@ -138,7 +146,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
     super.executableName,
     super.description, {
     super.suggestionDistanceLimit,
-    MessageOutput? messageOutput,
+    MessageOutput? messageOutput = const MessageOutput(usageLogger: print),
     SetLogLevel? setLogLevel,
     OnBeforeRunCommand? onBeforeRunCommand,
     OnAnalyticsEvent? onAnalyticsEvent,

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -162,13 +162,16 @@ class BetterCommandRunner<O extends OptionDefinition, T>
         ) {
     if (globalOptions != null) {
       _globalOptions = globalOptions;
-    } else if (_onAnalyticsEvent != null) {
-      _globalOptions = StandardGlobalOption.values as List<O>;
-    } else {
-      _globalOptions = [
+    } else if (O == OptionDefinition || O == StandardGlobalOption) {
+      _globalOptions = <O>[
         StandardGlobalOption.quiet as O,
         StandardGlobalOption.verbose as O,
+        if (_onAnalyticsEvent != null) StandardGlobalOption.analytics as O,
       ];
+    } else {
+      throw ArgumentError(
+        'globalOptions not provided and O is not assignable from StandardGlobalOption: $O',
+      );
     }
     prepareOptionsForParsing(_globalOptions, argParser);
   }

--- a/lib/src/better_command_runner/config_resolver.dart
+++ b/lib/src/better_command_runner/config_resolver.dart
@@ -11,11 +11,15 @@ import 'package:cli_tools/config.dart' show Configuration, OptionDefinition;
 /// The purpose of this class is to delegate the configuration resolution
 /// in BetterCommandRunner and BetterCommand to a separate object
 /// they can be composed with.
+///
+/// If invoked from global command runner or a command that has
+/// subcommands, set [ignoreUnexpectedPositionalArgs] to true.
 abstract interface class ConfigResolver<O extends OptionDefinition> {
   /// {@macro config_resolver}
   Configuration<O> resolveConfiguration({
     required Iterable<O> options,
     ArgResults? argResults,
+    bool ignoreUnexpectedPositionalArgs = false,
   });
 }
 
@@ -32,11 +36,13 @@ class DefaultConfigResolver<O extends OptionDefinition>
   Configuration<O> resolveConfiguration({
     required Iterable<O> options,
     ArgResults? argResults,
+    bool ignoreUnexpectedPositionalArgs = false,
   }) {
     return Configuration.resolve(
       options: options,
       argResults: argResults,
       env: _env,
+      ignoreUnexpectedPositionalArgs: ignoreUnexpectedPositionalArgs,
     );
   }
 }

--- a/lib/src/config/configuration.dart
+++ b/lib/src/config/configuration.dart
@@ -6,7 +6,10 @@ import 'package:meta/meta.dart';
 import 'option_resolution.dart';
 import 'source_type.dart';
 
-/// Common interface to enable same treatment for [ConfigOptionBase] and option enums.
+/// Common interface to enable same treatment for [ConfigOptionBase]
+/// and option enums.
+///
+/// [V] is the type of the value this option provides.
 abstract class OptionDefinition<V> {
   ConfigOptionBase<V> get option;
 }
@@ -52,7 +55,8 @@ class OptionGroup {
   int get hashCode => name.hashCode;
 }
 
-/// A [ValueParser] converts a source string value to the specific option value type.
+/// A [ValueParser] converts a source string value to the specific option
+/// value type.
 ///
 /// {@template value_parser}
 /// Must throw a [FormatException] with an appropriate message
@@ -85,7 +89,8 @@ abstract class ValueParser<V> {
 ///
 /// ### Typed values, parsing, and validation
 ///
-/// Option values are typed, and parsed using the [ValueParser].
+/// [V] is the type of the value this option provides.
+/// Option values are parsed to this type using the [ValueParser].
 /// Subclasses of [ConfigOptionBase] may also override [validateValue]
 /// to perform additional validation such as range checking.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   ci: ^0.1.0
   collection: ^1.18.0
   http: '>=0.13.0 <2.0.0'
-  meta: ^1.16.0
+  meta: ^1.11.0
   path: ^1.8.2
   pub_api_client: '>=2.4.0 <4.0.0'
   pub_semver: ^2.1.4

--- a/test/better_command_runner/analytics_test.dart
+++ b/test/better_command_runner/analytics_test.dart
@@ -59,6 +59,7 @@ void main() {
       'test',
       'this is a test cli',
       onAnalyticsEvent: null,
+      messageOutput: const MessageOutput(),
     );
 
     test('when checking if analytics is enabled then false is returned.', () {
@@ -78,6 +79,7 @@ void main() {
       'test',
       'this is a test cli',
       onAnalyticsEvent: (event) {},
+      messageOutput: const MessageOutput(),
     );
 
     test('when checking if analytics is enabled then true is returned.', () {
@@ -96,6 +98,7 @@ void main() {
         'test',
         'this is a test cli',
         onAnalyticsEvent: (event) => events.add(event),
+        messageOutput: const MessageOutput(),
       );
       assert(runner.analyticsEnabled());
     });
@@ -208,6 +211,7 @@ void main() {
         'test',
         'this is a test cli',
         onAnalyticsEvent: (event) => events.add(event),
+        messageOutput: const MessageOutput(),
       )..addCommand(MockCommand());
       assert(runner.analyticsEnabled());
     });
@@ -272,6 +276,7 @@ void main() {
         'test',
         'this is a test cli',
         onAnalyticsEvent: (event) => events.add(event),
+        messageOutput: const MessageOutput(),
       )..addCommand(command);
       assert(runner.analyticsEnabled());
     });

--- a/test/better_command_runner/default_flags_test.dart
+++ b/test/better_command_runner/default_flags_test.dart
@@ -7,6 +7,7 @@ void main() {
       'test',
       'test description',
       onAnalyticsEvent: (event) {},
+      messageOutput: const MessageOutput(),
     );
 
     test(

--- a/test/better_command_runner/logging_test.dart
+++ b/test/better_command_runner/logging_test.dart
@@ -74,7 +74,7 @@ void main() {
         expect(
           errors.first,
           contains(
-            'Unexpected positional argument(s): \'this it not a valid command\'',
+            'Could not find a command named "this it not a valid command".',
           ),
         );
       });

--- a/test/better_command_runner/logging_test.dart
+++ b/test/better_command_runner/logging_test.dart
@@ -34,8 +34,8 @@ void main() {
       'test',
       'this is a test cli',
       messageOutput: MessageOutput(
-        logUsageException: (e) => errors.add(e.toString()),
-        logUsage: (u) => infos.add(u),
+        usageExceptionLogger: (e) => errors.add(e.toString()),
+        usageLogger: (u) => infos.add(u),
       ),
     )..addCommand(MockCommand());
     tearDown(() {

--- a/test/better_command_runner/parse_log_level_test.dart
+++ b/test/better_command_runner/parse_log_level_test.dart
@@ -27,6 +27,7 @@ void main() {
     var runner = BetterCommandRunner(
       'test',
       'this is a test cli',
+      messageOutput: const MessageOutput(),
       setLogLevel: ({
         required CommandRunnerLogLevel parsedLogLevel,
         String? commandName,

--- a/test/better_command_test.dart
+++ b/test/better_command_test.dart
@@ -50,7 +50,7 @@ void main() {
     var infos = <String>[];
     var analyticsEvents = <String>[];
     var messageOutput = MessageOutput(
-      logUsage: (u) => infos.add(u),
+      usageLogger: (u) => infos.add(u),
     );
 
     var betterCommand = MockCommand(
@@ -149,7 +149,7 @@ void main() {
     var infos = <String>[];
     var analyticsEvents = <String>[];
     var messageOutput = MessageOutput(
-      logUsage: (u) => infos.add(u),
+      usageLogger: (u) => infos.add(u),
     );
 
     var betterCommand = MockCommand(
@@ -199,7 +199,7 @@ void main() {
       'without analytics set up and default global options', () {
     var infos = <String>[];
     var messageOutput = MessageOutput(
-      logUsage: (u) => infos.add(u),
+      usageLogger: (u) => infos.add(u),
     );
 
     var betterCommand = MockCommand(
@@ -248,7 +248,7 @@ void main() {
       'with additional global options', () {
     var infos = <String>[];
     var messageOutput = MessageOutput(
-      logUsage: (u) => infos.add(u),
+      usageLogger: (u) => infos.add(u),
     );
 
     var betterCommand = MockCommand(


### PR DESCRIPTION
Made the default usage / getting started experience with `BetterCommand` and `BetterCommandRunner`simpler and more consistent.

- The default terminal usage output behavior is now the same as the args package `Command` / `CommandRunner`
- Subcommands automatically inherit config resolution and output behavior from their command runner unless overridden
- Some minor refactoring
- Crafted a full example of using `BetterCommandRunner`, `BetterCommand`, and `Configuration` options in the example folder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command to generate customizable timestamp series with options for interval, length, or end time.
  - Added global quiet and verbose flags for dynamic log level control.

- **Improvements**
  - Enhanced usage error handling with clearer feedback.
  - Improved configuration and logging inheritance from the command runner.
  - Refined option parsing to enforce mutually exclusive and mandatory options.
  - Renamed global options enum for clarity and stricter typing.
  - Ensured asynchronous command execution with proper configuration resolution.

- **Bug Fixes**
  - Updated error messages for invalid commands to be more descriptive.

- **Documentation**
  - Clarified and expanded documentation for option types and configuration interfaces.

- **Tests**
  - Updated tests to align with logging and configuration changes, maintaining consistent coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->