### PR TITLE
chore: Bump version to 0.5.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
+## 0.5.0-beta.5
+
+- refactor: Support ConfigurationBroker that depends on dynamic state
+- refactor: Support bespoke Configuration subclass
+- refactor: Simplified default usage of BetterCommand/Runner
+- refactor: Subcommands inherit output behavior from their command runner unless overridden
+- refactor: The default terminal usage output behavior is now the same as the args package `Command` / `CommandRunner`
+- docs: A full example of using `BetterCommandRunner`, `BetterCommand`, and `Configuration` options in the example folder
+
 ## 0.5.0-beta.4
 
-- fix!: Clarified behavior of mutually exclusive option groups
+- fix: BREAKING. Clarified behavior of mutually exclusive option groups
 
 ## 0.5.0-beta.3
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.5.0-beta.4
+version: 0.5.0-beta.5
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with a new entry for version 0.5.0-beta.5, detailing recent refactorings and documentation improvements.
  - Clarified a previous changelog entry for version 0.5.0-beta.4.
- **Chores**
  - Bumped the package version to 0.5.0-beta.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->