### PR TITLE
feat: Support custom default unit in DurationParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+- feat: Support specifying a default unit other than seconds in DurationParser.
+- docs: Moved config readme into main readme.
+
 ## 0.5.0
 
 - feat: Introduced the `config` library for unified args and env parsing

--- a/lib/src/config/options.dart
+++ b/lib/src/config/options.dart
@@ -295,12 +295,27 @@ class DateTimeOption extends ComparableValueOption<DateTime> {
   }) : super(valueParser: const DateTimeParser());
 }
 
+/// The time units supported by the [DurationParser].
+enum DurationUnit {
+  microseconds('us'),
+  milliseconds('ms'),
+  seconds('s'),
+  minutes('m'),
+  hours('h'),
+  days('d');
+
+  final String suffix;
+
+  const DurationUnit(this.suffix);
+}
+
 /// Parses a duration string into a [Duration] object.
 ///
 /// The input string must be a number followed by an optional unit
 /// which is one of: seconds (s), minutes (m), hours (h), days (d),
 /// milliseconds (ms), or microseconds (us).
-/// If no unit is specified, seconds are assumed.
+/// If no unit is specified, the [defaultUnit] is assumed, which is in
+/// seconds if not specified otherwise.
 /// Examples:
 /// - `10`, equivalent to `10s`
 /// - `10m`
@@ -311,9 +326,9 @@ class DateTimeOption extends ComparableValueOption<DateTime> {
 ///
 /// Throws [FormatException] if parsing failed.
 class DurationParser extends ValueParser<Duration> {
-  final String defaultUnit;
+  final DurationUnit defaultUnit;
 
-  const DurationParser({this.defaultUnit = 's'});
+  const DurationParser({this.defaultUnit = DurationUnit.seconds});
 
   @override
   Duration parse(final String value) {
@@ -326,24 +341,25 @@ class DurationParser extends ValueParser<Duration> {
       throw FormatException('Invalid duration value "$value"');
     }
     final valueStr = match.group(1);
-    final unit = match.group(2) ?? defaultUnit;
+    final unit = _determineUnit(match.group(2));
     final val = int.parse(valueStr ?? '');
-    switch (unit) {
-      case 's':
-        return Duration(seconds: val);
-      case 'm':
-        return Duration(minutes: val);
-      case 'h':
-        return Duration(hours: val);
-      case 'd':
-        return Duration(days: val);
-      case 'ms':
-        return Duration(milliseconds: val);
-      case 'us':
-        return Duration(microseconds: val);
-      default:
-        throw FormatException('Invalid duration unit "$unit".');
-    }
+    return switch (unit) {
+      DurationUnit.seconds => Duration(seconds: val),
+      DurationUnit.minutes => Duration(minutes: val),
+      DurationUnit.hours => Duration(hours: val),
+      DurationUnit.days => Duration(days: val),
+      DurationUnit.milliseconds => Duration(milliseconds: val),
+      DurationUnit.microseconds => Duration(microseconds: val),
+    };
+  }
+
+  DurationUnit _determineUnit(final String? suffix) {
+    if (suffix == null) return defaultUnit;
+
+    return DurationUnit.values.firstWhere(
+      (final unit) => unit.suffix == suffix,
+      orElse: () => throw FormatException('Invalid duration unit "$suffix".'),
+    );
   }
 
   @override

--- a/lib/src/config/options.dart
+++ b/lib/src/config/options.dart
@@ -311,7 +311,9 @@ class DateTimeOption extends ComparableValueOption<DateTime> {
 ///
 /// Throws [FormatException] if parsing failed.
 class DurationParser extends ValueParser<Duration> {
-  const DurationParser();
+  final String defaultUnit;
+
+  const DurationParser({this.defaultUnit = 's'});
 
   @override
   Duration parse(final String value) {
@@ -324,7 +326,7 @@ class DurationParser extends ValueParser<Duration> {
       throw FormatException('Invalid duration value "$value"');
     }
     final valueStr = match.group(1);
-    final unit = match.group(2) ?? 's';
+    final unit = match.group(2) ?? defaultUnit;
     final val = int.parse(valueStr ?? '');
     switch (unit) {
       case 's':
@@ -383,7 +385,7 @@ class DurationOption extends ComparableValueOption<Duration> {
     super.fromDefault,
     super.defaultsTo,
     super.helpText,
-    super.valueHelp = 'integer[s|m|h|d]',
+    super.valueHelp = 'integer[us|ms|s|m|h|d]',
     super.allowedHelp,
     super.group,
     super.allowedValues,
@@ -393,4 +395,29 @@ class DurationOption extends ComparableValueOption<Duration> {
     super.min,
     super.max,
   }) : super(valueParser: const DurationParser());
+
+  /// Creates a DurationOption with a custom duration parser,
+  /// e.g. with a specific default unit.
+  const DurationOption.custom({
+    required final DurationParser parser,
+    super.argName,
+    super.argAliases,
+    super.argAbbrev,
+    super.argPos,
+    super.envName,
+    super.configKey,
+    super.fromCustom,
+    super.fromDefault,
+    super.defaultsTo,
+    super.helpText,
+    super.valueHelp = 'integer[us|ms|s|m|h|d]',
+    super.allowedHelp,
+    super.group,
+    super.allowedValues,
+    super.customValidator,
+    super.mandatory,
+    super.hide,
+    super.min,
+    super.max,
+  }) : super(valueParser: parser);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.5.0
+version: 0.5.1
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev

--- a/test/config/configuration_type_test.dart
+++ b/test/config/configuration_type_test.dart
@@ -263,7 +263,7 @@ void main() async {
       expect(
         config.errors.single,
         equals(
-            'Invalid value for option `duration` <integer[s|m|h|d]>: -2s is below the minimum (0s)'),
+            'Invalid value for option `duration` <integer[us|ms|s|m|h|d]>: -2s is below the minimum (0s)'),
       );
     });
 
@@ -279,7 +279,7 @@ void main() async {
       expect(
         config.errors.single,
         equals(
-            'Invalid value for option `duration` <integer[s|m|h|d]>: 20d is above the maximum (2d)'),
+            'Invalid value for option `duration` <integer[us|ms|s|m|h|d]>: 20d is above the maximum (2d)'),
       );
     });
   });

--- a/test/config/duration_parsing_test.dart
+++ b/test/config/duration_parsing_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 import 'package:cli_tools/config.dart';
 
 void main() {
-  group('Given a DurationParser', () {
+  group('Given a DurationParser with normal default unit "s"', () {
     const durationParser = DurationParser();
 
     test('when calling parse with empty string then it throws FormatException.',
@@ -248,6 +248,61 @@ void main() {
         () {
       expect(durationParser.format(const Duration(days: 2, hours: 22)),
           equals('2d22h'));
+    });
+  });
+
+  group('Given a DurationParser with custom default unit "ms"', () {
+    const durationParser = DurationParser(defaultUnit: 'ms');
+
+    test('when calling parse with empty string then it throws FormatException.',
+        () {
+      expect(
+        () => durationParser.parse(''),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('when calling parse with "-" then it throws FormatException.', () {
+      expect(
+        () => durationParser.parse('-'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test(
+        'when calling parse with just an ms unit then it throws FormatException.',
+        () {
+      expect(
+        () => durationParser.parse('ms'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test(
+        'when calling parse with 10 (implicit ms unit) then it successfully returns a 10ms Duration.',
+        () {
+      expect(
+        durationParser.parse('10'),
+        equals(const Duration(milliseconds: 10)),
+      );
+    });
+
+    test(
+        'when calling parse with 10ms then it successfully returns a 10ms Duration.',
+        () {
+      expect(
+        durationParser.parse('10ms'),
+        equals(const Duration(milliseconds: 10)),
+      );
+    });
+
+    test(
+        'when calling parse with 10s then it successfully returns a 10s Duration.',
+        () {
+      expect(
+        durationParser.parse('10s'),
+        equals(const Duration(seconds: 10)),
+      );
     });
   });
 }

--- a/test/config/duration_parsing_test.dart
+++ b/test/config/duration_parsing_test.dart
@@ -252,7 +252,9 @@ void main() {
   });
 
   group('Given a DurationParser with custom default unit "ms"', () {
-    const durationParser = DurationParser(defaultUnit: 'ms');
+    const durationParser = DurationParser(
+      defaultUnit: DurationUnit.milliseconds,
+    );
 
     test('when calling parse with empty string then it throws FormatException.',
         () {


### PR DESCRIPTION
Support for specifying a default unit other than seconds in DurationParser.

Bump patch version to 0.5.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom default unit when parsing durations. Now, if a unit is omitted, the parser uses the configured default unit instead of always defaulting to seconds.
  - Introduced an option to create duration configuration options with a custom parser and default unit.

- **Bug Fixes**
  - Improved help text for duration options to include microseconds and milliseconds.

- **Tests**
  - Added tests to verify duration parsing with custom default units and updated test descriptions for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->