### PR TITLE
feat!: By default resolve throws informative UsageException

### DIFF
--- a/example/config_file_example.dart
+++ b/example/config_file_example.dart
@@ -60,7 +60,7 @@ class TimeSeriesCommand extends BetterCommand<TimeSeriesOption, void> {
 
   @override
   Configuration<TimeSeriesOption> resolveConfiguration(ArgResults? argResults) {
-    return Configuration.resolve(
+    return Configuration.resolveNoExcept(
       options: options,
       argResults: argResults,
       env: envVariables,

--- a/lib/src/better_command_runner/better_command.dart
+++ b/lib/src/better_command_runner/better_command.dart
@@ -122,7 +122,7 @@ abstract class BetterCommand<O extends OptionDefinition, T> extends Command<T> {
   /// This method can be overridden to change the configuration resolution
   /// behavior.
   Configuration<O> resolveConfiguration(ArgResults? argResults) {
-    return Configuration.resolve(
+    return Configuration.resolveNoExcept(
       options: options,
       argResults: argResults,
       env: envVariables,

--- a/lib/src/better_command_runner/better_command.dart
+++ b/lib/src/better_command_runner/better_command.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/config.dart';
+import 'package:cli_tools/src/config/output_formatting.dart';
 
 import 'better_command_runner.dart';
 

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -309,7 +309,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
   /// This method can be overridden to change the configuration resolution
   /// behavior.
   Configuration<O> resolveConfiguration(ArgResults? argResults) {
-    return Configuration.resolve(
+    return Configuration.resolveNoExcept(
       options: _globalOptions,
       argResults: argResults,
       env: envVariables,

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/config.dart';
+import 'package:cli_tools/src/config/output_formatting.dart';
 
 /// A function type for executing code before running a command.
 typedef OnBeforeRunCommand = Future<void> Function(BetterCommandRunner runner);
@@ -383,15 +384,3 @@ abstract class BetterCommandRunnerAnalyticsEvents {
 
 /// An enum for the command runner log levels.
 enum CommandRunnerLogLevel { quiet, verbose, normal }
-
-/// Formats a configuration error message.
-String formatConfigError(final String error) {
-  if (error.isEmpty) return error;
-  final suffix = _isPunctuation(error.substring(error.length - 1)) ? '' : '.';
-  return '${error[0].toUpperCase()}${error.substring(1)}$suffix';
-}
-
-/// Returns true if the character is a punctuation mark.
-bool _isPunctuation(final String char) {
-  return RegExp(r'\p{P}', unicode: true).hasMatch(char);
-}

--- a/lib/src/config/config_parser.dart
+++ b/lib/src/config/config_parser.dart
@@ -1,7 +1,6 @@
 import 'dart:io' show Platform;
 
 import 'package:args/args.dart';
-import 'package:args/command_runner.dart' show UsageException;
 
 import 'configuration.dart';
 import 'configuration_broker.dart';
@@ -250,13 +249,6 @@ class ConfigParser implements ArgParser {
       presetValues: presetValues,
       ignoreUnexpectedPositionalArgs: true,
     );
-
-    if (configuration.errors.isNotEmpty) {
-      throw UsageException(
-        configuration.errors.join('\n'),
-        usage,
-      );
-    }
 
     _invokeCallbacks(configuration);
 

--- a/lib/src/config/configuration.dart
+++ b/lib/src/config/configuration.dart
@@ -116,7 +116,7 @@ class Configuration<O extends OptionDefinition> {
   ///
   /// Throws a [UsageException] with error and correct usage information
   /// if there were any errors during configuration resolution.
-  /// A caller can use [resolveNoExcept] insteadto handle the errors themselves.
+  /// A caller can use [resolveNoExcept] instead to handle the errors themselves.
   factory Configuration.resolve({
     required final Iterable<O> options,
     final ArgResults? argResults,

--- a/lib/src/config/configuration.dart
+++ b/lib/src/config/configuration.dart
@@ -264,7 +264,7 @@ class Configuration<O extends OptionDefinition> {
     final resolution = _config[option];
 
     if (resolution == null) {
-      throw InvalidOptionConfigurationError(option,
+      throw OptionDefinitionError(option,
           'Out-of-order dependency on not-yet-resolved ${option.qualifiedString()}');
     }
 

--- a/lib/src/config/exceptions.dart
+++ b/lib/src/config/exceptions.dart
@@ -1,16 +1,16 @@
 import 'package:cli_tools/src/config/options.dart';
 
 /// Indicates that the option definition is invalid.
-class InvalidOptionConfigurationError extends Error {
+class OptionDefinitionError extends Error {
   final OptionDefinition option;
   final String? message;
 
-  InvalidOptionConfigurationError(this.option, [this.message]);
+  OptionDefinitionError(this.option, [this.message]);
 
   @override
   String toString() {
     return message != null
-        ? 'Invalid configuration for ${option.qualifiedString()}: $message'
-        : 'Invalid configuration for ${option.qualifiedString()}';
+        ? 'Invalid definition for ${option.qualifiedString()}: $message'
+        : 'Invalid definition for ${option.qualifiedString()}';
   }
 }

--- a/lib/src/config/option_groups.dart
+++ b/lib/src/config/option_groups.dart
@@ -39,7 +39,7 @@ class MutuallyExclusive extends OptionGroup {
 
     for (final opt in options) {
       if (opt.option.defaultValue() != null) {
-        throw InvalidOptionConfigurationError(
+        throw OptionDefinitionError(
           opt,
           'Option group `$name` does not allow defaults',
         );

--- a/lib/src/config/option_types.dart
+++ b/lib/src/config/option_types.dart
@@ -333,7 +333,7 @@ class DurationParser extends ValueParser<Duration> {
   @override
   Duration parse(final String value) {
     // integer followed by an optional unit (s, m, h, d, ms, us)
-    const pattern = r'^(-?\d+)([smhd]|ms|us)?$';
+    const pattern = r'^(-?\d+)(ms|us|[smhd])?$';
     final regex = RegExp(pattern);
     final match = regex.firstMatch(value);
 

--- a/lib/src/config/options.dart
+++ b/lib/src/config/options.dart
@@ -266,12 +266,12 @@ abstract class ConfigOptionBase<V> implements OptionDefinition<V> {
   @mustCallSuper
   void validateDefinition() {
     if (argName == null && argAbbrev != null) {
-      throw InvalidOptionConfigurationError(this,
+      throw OptionDefinitionError(this,
           "An argument option can't have an abbreviation but not a full name");
     }
 
     if ((fromDefault != null || defaultsTo != null) && mandatory) {
-      throw InvalidOptionConfigurationError(
+      throw OptionDefinitionError(
           this, "Mandatory options can't have default values");
     }
   }
@@ -733,7 +733,7 @@ Iterable<OptionDefinition> validateOptions(
     final argName = opt.option.argName;
     if (argName != null) {
       if (argNameOpts.containsKey(opt.option.argName)) {
-        throw InvalidOptionConfigurationError(
+        throw OptionDefinitionError(
             opt, 'Duplicate argument name: ${opt.option.argName} for $opt');
       }
       argNameOpts[argName] = opt;
@@ -742,7 +742,7 @@ Iterable<OptionDefinition> validateOptions(
     final argPos = opt.option.argPos;
     if (argPos != null) {
       if (argPosOpts.containsKey(opt.option.argPos)) {
-        throw InvalidOptionConfigurationError(
+        throw OptionDefinitionError(
             opt, 'Duplicate argument position: ${opt.option.argPos} for $opt');
       }
       argPosOpts[argPos] = opt;
@@ -751,7 +751,7 @@ Iterable<OptionDefinition> validateOptions(
     final envName = opt.option.envName;
     if (envName != null) {
       if (envNameOpts.containsKey(opt.option.envName)) {
-        throw InvalidOptionConfigurationError(opt,
+        throw OptionDefinitionError(opt,
             'Duplicate environment variable name: ${opt.option.envName} for $opt');
       }
       envNameOpts[envName] = opt;
@@ -776,14 +776,14 @@ Iterable<OptionDefinition> validateOptions(
         (final a, final b) => a.option.argPos!.compareTo(b.option.argPos!));
 
     if (orderedPosOpts.first.option.argPos != 0) {
-      throw InvalidOptionConfigurationError(
+      throw OptionDefinitionError(
         orderedPosOpts.first,
         'First positional argument must have index 0.',
       );
     }
 
     if (orderedPosOpts.last.option.argPos != orderedPosOpts.length - 1) {
-      throw InvalidOptionConfigurationError(
+      throw OptionDefinitionError(
         orderedPosOpts.last,
         'The positional arguments must have consecutive indices without gaps.',
       );

--- a/lib/src/config/output_formatting.dart
+++ b/lib/src/config/output_formatting.dart
@@ -1,0 +1,11 @@
+/// Formats a configuration error message.
+String formatConfigError(final String error) {
+  if (error.isEmpty) return error;
+  final suffix = _isPunctuation(error.substring(error.length - 1)) ? '' : '.';
+  return '${error[0].toUpperCase()}${error.substring(1)}$suffix';
+}
+
+/// Returns true if the character is a punctuation mark.
+bool _isPunctuation(final String char) {
+  return RegExp(r'\p{P}', unicode: true).hasMatch(char);
+}

--- a/test/config/config_source_test.dart
+++ b/test/config/config_source_test.dart
@@ -45,7 +45,7 @@ void main() {
     test(
         'when the YAML content option has data '
         'then the correct value is retrieved', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [
           '--yaml-content',
@@ -65,7 +65,7 @@ project:
     test(
         'when the JSON content option has data '
         'then the correct value is retrieved', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [
           '--json-content',
@@ -88,7 +88,7 @@ project:
     test(
         'when the YAML content option has data of the wrong type '
         'then an appropriate error is registered', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [
           '--yaml-content',
@@ -117,7 +117,7 @@ project:
     test(
         'when the JSON content option has data of the wrong type '
         'then an appropriate error is registered', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [
           '--json-content',
@@ -149,7 +149,7 @@ project:
     test(
         'when the YAML content option has malformed data '
         'then an appropriate error is registered', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [
           '--yaml-content',
@@ -176,7 +176,7 @@ projectId:123
     test(
         'when the JSON content option has malformed data '
         'then an appropriate error is registered', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [
           '--json-content',
@@ -242,7 +242,7 @@ projectId:123
         'when creating the configuration '
         'then the expected errors are registered', () async {
       expect(
-        () => Configuration.resolve(
+        () => Configuration.resolveNoExcept(
           options: options,
           configBroker: configSource,
         ),

--- a/test/config/configuration_test.dart
+++ b/test/config/configuration_test.dart
@@ -14,7 +14,7 @@ void main() async {
       expect(
         () => [projectIdOpt].prepareForParsing(parser),
         throwsA(allOf(
-          isA<InvalidOptionConfigurationError>(),
+          isA<OptionDefinitionError>(),
           (final e) => e.toString().contains(
                 "An argument option can't have an abbreviation but not a full name",
               ),
@@ -34,7 +34,7 @@ void main() async {
       expect(
         () => [projectIdOpt].prepareForParsing(parser),
         throwsA(allOf(
-          isA<InvalidOptionConfigurationError>(),
+          isA<OptionDefinitionError>(),
           (final e) => e
               .toString()
               .contains("Mandatory options can't have default values"),
@@ -57,7 +57,7 @@ void main() async {
       expect(
         () => [projectIdOpt].prepareForParsing(parser),
         throwsA(allOf(
-          isA<InvalidOptionConfigurationError>(),
+          isA<OptionDefinitionError>(),
           (final e) => e
               .toString()
               .contains("Mandatory options can't have default values"),
@@ -574,7 +574,7 @@ void main() async {
         () async {
       final parser = ArgParser();
       expect(() => [argNameOpt, duplicateOpt].prepareForParsing(parser),
-          throwsA(isA<InvalidOptionConfigurationError>()));
+          throwsA(isA<OptionDefinitionError>()));
     });
 
     test(
@@ -582,7 +582,7 @@ void main() async {
         () async {
       final parser = ArgParser();
       expect(() => [envNameOpt, duplicateOpt].prepareForParsing(parser),
-          throwsA(isA<InvalidOptionConfigurationError>()));
+          throwsA(isA<OptionDefinitionError>()));
     });
 
     test(
@@ -590,7 +590,7 @@ void main() async {
         () async {
       final parser = ArgParser();
       expect(() => [argPosOpt, duplicateOpt].prepareForParsing(parser),
-          throwsA(isA<InvalidOptionConfigurationError>()));
+          throwsA(isA<OptionDefinitionError>()));
     });
 
     test(
@@ -598,7 +598,7 @@ void main() async {
         () async {
       final parser = ArgParser();
       expect(() => [argPosOpt, argPos2Opt].prepareForParsing(parser),
-          throwsA(isA<InvalidOptionConfigurationError>()));
+          throwsA(isA<OptionDefinitionError>()));
     });
 
     test(
@@ -606,7 +606,7 @@ void main() async {
         () async {
       final parser = ArgParser();
       expect(() => [argPos2Opt].prepareForParsing(parser),
-          throwsA(isA<InvalidOptionConfigurationError>()));
+          throwsA(isA<OptionDefinitionError>()));
     });
   });
 
@@ -1268,7 +1268,7 @@ void main() async {
           options: options,
           args: [],
         ),
-        throwsA(isA<InvalidOptionConfigurationError>().having(
+        throwsA(isA<OptionDefinitionError>().having(
           (final e) => e.message,
           'message',
           'Option group `mutex-group` does not allow defaults',
@@ -1438,7 +1438,7 @@ void main() async {
           env: <String, String>{},
           configBroker: configSource,
         ),
-        throwsA(isA<InvalidOptionConfigurationError>().having(
+        throwsA(isA<OptionDefinitionError>().having(
             (final e) => e.message,
             'message',
             'Out-of-order dependency on not-yet-resolved option `file`')),

--- a/test/config/configuration_test.dart
+++ b/test/config/configuration_test.dart
@@ -135,7 +135,7 @@ void main() async {
     test(
         'when getting the usage from a resolved configuration '
         'then the usage is returned', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
       );
       expect(
@@ -147,7 +147,7 @@ void main() async {
     test('then command line argument has first precedence', () async {
       final args = ['--project', '123'];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -160,7 +160,7 @@ void main() async {
     test('then env variable has second precedence', () async {
       final args = <String>[];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -173,7 +173,7 @@ void main() async {
     test('then configKey has third precedence', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -186,7 +186,7 @@ void main() async {
     test('then fromCustom function has fourth precedence', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -199,7 +199,7 @@ void main() async {
       // Note: This is the behavior of ArgParser.
       // It may be considered to make this a usage error instead.
       final args = ['--project', '123', '--project', '456'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
       );
@@ -219,7 +219,7 @@ void main() async {
     test('then command line argument has first precedence', () async {
       final args = ['--project', '123'];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -232,7 +232,7 @@ void main() async {
     test('then env variable has second precedence', () async {
       final args = <String>[];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -245,7 +245,7 @@ void main() async {
     test('then configKey has third precedence', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -258,7 +258,7 @@ void main() async {
     test('then defaultsTo value has last precedence', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -278,7 +278,7 @@ void main() async {
     test('then command line argument has first precedence', () async {
       final args = ['--verbose'];
       final envVars = {'VERBOSE': 'false'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [verboseFlag],
         args: args,
         env: envVars,
@@ -289,7 +289,7 @@ void main() async {
     test('then env variable has second precedence', () async {
       final args = <String>[];
       final envVars = {'VERBOSE': 'true'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [verboseFlag],
         args: args,
         env: envVars,
@@ -308,7 +308,7 @@ void main() async {
     test('then defaultsTo value has last precedence', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [verboseFlag],
         args: args,
         env: envVars,
@@ -328,7 +328,7 @@ void main() async {
         () async {
       final args = ['--project', '123'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -340,7 +340,7 @@ void main() async {
         () async {
       final args = <String>[];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -351,7 +351,7 @@ void main() async {
     test('when not provided then calling value() throws StateError', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -362,7 +362,7 @@ void main() async {
     test('when provided as argument then parsing succeeds', () async {
       final args = ['--project', '123'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -373,7 +373,7 @@ void main() async {
     test('when provided as env variable then parsing succeeds', () async {
       final args = <String>[];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -385,7 +385,7 @@ void main() async {
         () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -401,10 +401,65 @@ void main() async {
       mandatory: true,
     );
 
+    test(
+        'when not provided and calling resolveNoExcept '
+        'then it returns normally with a registered error message', () async {
+      final args = <String>[];
+      final envVars = <String, String>{};
+      final config = Configuration.resolveNoExcept(
+        options: [projectIdOpt],
+        args: args,
+        env: envVars,
+      );
+      expect(config.errors, hasLength(1));
+      expect(config.errors.first, 'option `project` is mandatory');
+      expect(
+        () => config.value(projectIdOpt),
+        throwsA(isA<StateError>().having(
+          (final e) => e.message,
+          'message',
+          contains(
+              'No value available for option `project` due to previous errors'),
+        )),
+      );
+    });
+
+    test(
+        'when not provided and calling resolve '
+        'then it throws a UsageException', () async {
+      final args = <String>[];
+      final envVars = <String, String>{};
+      expect(
+          () => Configuration.resolve(
+                options: [projectIdOpt],
+                args: args,
+                env: envVars,
+              ),
+          throwsA(isA<UsageException>()
+              .having(
+                (final e) => e.message,
+                'message',
+                contains('Option `project` is mandatory.'),
+              )
+              .having(
+                (final e) => e.usage,
+                'usage',
+                contains('--project (mandatory)'),
+              )));
+    });
+  });
+
+  group('Given a mandatory configuration option', () {
+    const projectIdOpt = StringOption(
+      argName: 'project',
+      envName: 'PROJECT_ID',
+      mandatory: true,
+    );
+
     test('when provided as argument then parsing succeeds', () async {
       final args = ['--project', '123'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -416,7 +471,7 @@ void main() async {
     test('when provided as env variable then parsing succeeds', () async {
       final args = <String>[];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -428,7 +483,7 @@ void main() async {
     test('when not provided then parsing has error', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -463,7 +518,7 @@ void main() async {
     test('when provided as env variable then parsing succeeds', () async {
       final args = <String>[];
       final envVars = {'PROJECT_ID': '456'};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -475,7 +530,7 @@ void main() async {
     test('when not provided then parsing has error', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [projectIdOpt],
         args: args,
         env: envVars,
@@ -568,7 +623,7 @@ void main() async {
         () async {
       final args = ['pos-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -580,7 +635,7 @@ void main() async {
     test('when provided before named argument then parsing succeeds', () async {
       final args = ['pos-arg', '--project', '123'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -592,7 +647,7 @@ void main() async {
     test('when provided after named argument then parsing succeeds', () async {
       final args = ['--project', '123', 'pos-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -606,7 +661,7 @@ void main() async {
         () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -619,7 +674,7 @@ void main() async {
         () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -643,7 +698,7 @@ void main() async {
         () async {
       final args = ['pos-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -655,7 +710,7 @@ void main() async {
     test('when provided before named argument then parsing succeeds', () async {
       final args = ['pos-arg', '--project', '123'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -667,7 +722,7 @@ void main() async {
     test('when provided after named argument then parsing succeeds', () async {
       final args = ['--project', '123', 'pos-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -679,7 +734,7 @@ void main() async {
     test('when not provided then parsing has error', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -713,7 +768,7 @@ void main() async {
         () async {
       final args = ['1st-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -727,7 +782,7 @@ void main() async {
         () async {
       final args = ['--first', '1st-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -742,7 +797,7 @@ void main() async {
         () async {
       final args = ['--second', '2st-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -756,7 +811,7 @@ void main() async {
         () async {
       final args = ['1st-arg', '2nd-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -771,7 +826,7 @@ void main() async {
         () async {
       final args = ['1st-arg', '--second', '2nd-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -786,7 +841,7 @@ void main() async {
         () async {
       final args = ['--first', '1st-arg', '2nd-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -801,7 +856,7 @@ void main() async {
         () async {
       final args = ['2nd-arg', '--first', '1st-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -814,7 +869,7 @@ void main() async {
     test('when provided as 2 named arguments then parsing succeeds', () async {
       final args = ['--first', '1st-arg', '--second', '2nd-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -829,7 +884,7 @@ void main() async {
         () async {
       final args = ['--second', '2nd-arg', '--first', '1st-arg'];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -842,7 +897,7 @@ void main() async {
     test('when not provided then parsing succeeds and both are null', () async {
       final args = <String>[];
       final envVars = <String, String>{};
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -857,7 +912,7 @@ void main() async {
       final args = ['1st-arg', '2nd-arg', '3rd-arg'];
       final envVars = <String, String>{};
 
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -875,7 +930,7 @@ void main() async {
       final args = ['--first', '1st-arg', '--second', '2nd-arg', '3rd-arg'];
       final envVars = <String, String>{};
 
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
         env: envVars,
@@ -903,7 +958,7 @@ void main() async {
         'when the first option is provided using primary name then parsing succeeds',
         () async {
       final args = ['--first', '1st-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -916,7 +971,7 @@ void main() async {
         'when the first option is provided using first alias then parsing succeeds',
         () async {
       final args = ['--alias-first-a', '1st-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -929,7 +984,7 @@ void main() async {
         'when the first option is provided using second alias then parsing succeeds',
         () async {
       final args = ['--alias-first-b', '1st-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -942,7 +997,7 @@ void main() async {
         'when the first option is provided twice using aliases then the last value is used',
         () async {
       final args = ['--alias-first-a', '1st-arg', '--alias-first-b', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -960,7 +1015,7 @@ void main() async {
         '--alias-second-b',
         '2nd-arg'
       ];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -988,7 +1043,7 @@ void main() async {
         'when the first of the mut-ex options is provided as argument then parsing succeeds',
         () async {
       final args = ['--first', '1st-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1001,7 +1056,7 @@ void main() async {
         'when the second of the mut-ex options is provided as argument then parsing succeeds',
         () async {
       final args = ['--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1013,7 +1068,7 @@ void main() async {
     test(
         'when the first of the mut-ex options is provided as env var then parsing succeeds',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         env: {'FIRST': '1st-arg'},
       );
@@ -1025,7 +1080,7 @@ void main() async {
     test(
         'when the second of the mut-ex options is provided as env var then parsing succeeds',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         env: {'SECOND': '2nd-arg'},
       );
@@ -1038,7 +1093,7 @@ void main() async {
         'when both mut-ex options are provided as arguments then parsing has error',
         () async {
       final args = ['--first', '1st-arg', '--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1052,7 +1107,7 @@ void main() async {
     test(
         'when both mut-ex options are provided as arg and env var then parsing has error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: ['--first', '1st-arg'],
         env: {'SECOND': '2nd-arg'},
@@ -1067,7 +1122,7 @@ void main() async {
     test(
         'when neither of the mut-ex options are provided then parsing succeeds',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
       );
       expect(config.errors, isEmpty);
@@ -1097,7 +1152,7 @@ void main() async {
         'when the first of the mut-ex options is provided as argument then parsing succeeds',
         () async {
       final args = ['--first', '1st-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1110,7 +1165,7 @@ void main() async {
         'when the second of the mut-ex options is provided as argument then parsing succeeds',
         () async {
       final args = ['--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1122,7 +1177,7 @@ void main() async {
     test(
         'when the first of the mut-ex options is provided as env var then parsing succeeds',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         env: {'FIRST': '1st-arg'},
       );
@@ -1134,7 +1189,7 @@ void main() async {
     test(
         'when the second of the mut-ex options is provided as env var then parsing succeeds',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         env: {'SECOND': '2nd-arg'},
       );
@@ -1147,7 +1202,7 @@ void main() async {
         'when both mut-ex options are provided as arguments then parsing has error',
         () async {
       final args = ['--first', '1st-arg', '--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1161,7 +1216,7 @@ void main() async {
     test(
         'when both mut-ex options are provided as arg and env var then parsing has error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: ['--first', '1st-arg'],
         env: {'SECOND': '2nd-arg'},
@@ -1176,7 +1231,7 @@ void main() async {
     test(
         'when neither of the mut-ex options are provided then parsing has error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [],
         env: {},
@@ -1209,7 +1264,7 @@ void main() async {
 
     test('then option group validation throws error', () async {
       expect(
-        () => Configuration.resolve(
+        () => Configuration.resolveNoExcept(
           options: options,
           args: [],
         ),
@@ -1244,7 +1299,7 @@ void main() async {
         'when the first of the mut-ex options is provided as argument then parsing succeeds',
         () async {
       final args = ['--first', '1st-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1257,7 +1312,7 @@ void main() async {
         'when the second of the mut-ex options is provided as argument then both have values',
         () async {
       final args = ['--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1270,7 +1325,7 @@ void main() async {
         'when both mut-ex options are provided as arguments then parsing has error',
         () async {
       final args = ['--first', '1st-arg', '--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1284,7 +1339,7 @@ void main() async {
     test(
         'when neither of the mut-ex options are provided then parsing succeeds with default value',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: [],
       );
@@ -1316,7 +1371,7 @@ void main() async {
     test('when one option from each group is provided then parsing succeeds',
         () async {
       final args = ['--first', '1st-arg', '--third', '3rd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1331,7 +1386,7 @@ void main() async {
         'when two options from the same group are provided then parsing has error',
         () async {
       final args = ['--first', '1st-arg', '--second', '2nd-arg'];
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: args,
       );
@@ -1362,7 +1417,7 @@ void main() async {
         () async {
       final options = [configFileOpt, projectIdOpt];
 
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: options,
         args: ['--file', 'config.yaml'],
         env: <String, String>{},
@@ -1377,7 +1432,7 @@ void main() async {
       final options = [projectIdOpt, configFileOpt];
 
       expect(
-        () => Configuration.resolve(
+        () => Configuration.resolveNoExcept(
           options: options,
           args: ['--file', 'config.yaml'],
           env: <String, String>{},

--- a/test/config/configuration_type_test.dart
+++ b/test/config/configuration_type_test.dart
@@ -17,7 +17,7 @@ void main() async {
     );
 
     test('when passed a valid value then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--animal', 'cat'],
         env: <String, String>{},
@@ -26,7 +26,7 @@ void main() async {
     });
 
     test('when passed an invalid value then it reports an error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--animal', 'unicorn'],
         env: <String, String>{},
@@ -49,7 +49,7 @@ void main() async {
 
     test('when passed a valid positive value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '123'],
         env: <String, String>{},
@@ -59,7 +59,7 @@ void main() async {
 
     test('when passed a valid negative value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '-123'],
         env: <String, String>{},
@@ -68,7 +68,7 @@ void main() async {
     });
 
     test('when passed a non-integer value then it reports an error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '0.45'],
         env: <String, String>{},
@@ -81,7 +81,7 @@ void main() async {
       );
     });
     test('when passed a non-number value then it reports an error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', 'unicorn'],
         env: <String, String>{},
@@ -104,7 +104,7 @@ void main() async {
     );
 
     test('when passed a valid value then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '123'],
         env: <String, String>{},
@@ -115,7 +115,7 @@ void main() async {
     test(
         'when passed an integer value less than the range then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '99'],
         env: <String, String>{},
@@ -131,7 +131,7 @@ void main() async {
     test(
         'when passed an integer value greater than the range then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '201'],
         env: <String, String>{},
@@ -155,7 +155,7 @@ void main() async {
     );
 
     test('when passed a valid value then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '100'],
       );
@@ -164,7 +164,7 @@ void main() async {
 
     test('when passed an invalid integer value as arg then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--number', '99'],
       );
@@ -179,7 +179,7 @@ void main() async {
     test(
         'when passed an invalid integer value as env var then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'NUMBER': '99'},
       );
@@ -203,7 +203,7 @@ void main() async {
 
     test('when passed a valid days value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '1d'],
         env: <String, String>{},
@@ -213,7 +213,7 @@ void main() async {
 
     test('when passed a valid hours value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '2h'],
         env: <String, String>{},
@@ -223,7 +223,7 @@ void main() async {
 
     test('when passed a valid minutes value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '3m'],
         env: <String, String>{},
@@ -233,7 +233,7 @@ void main() async {
 
     test('when passed a valid seconds value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '24s'],
         env: <String, String>{},
@@ -243,7 +243,7 @@ void main() async {
 
     test('when passed a valid value with no unit then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '2'],
         env: <String, String>{},
@@ -253,7 +253,7 @@ void main() async {
 
     test('when passed a value less than the range then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '-2s'],
         env: <String, String>{},
@@ -269,7 +269,7 @@ void main() async {
 
     test('when passed a value greater than the range then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--duration', '20d'],
         env: <String, String>{},
@@ -293,7 +293,7 @@ void main() async {
     );
 
     test('when passed no values then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: [],
       );
@@ -302,7 +302,7 @@ void main() async {
 
     test('when passed a single arg value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123'],
       );
@@ -311,7 +311,7 @@ void main() async {
 
     test('when passed several arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123', '--many', '456'],
       );
@@ -321,7 +321,7 @@ void main() async {
     test(
         'when passed several comma-separated arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123,456'],
       );
@@ -329,7 +329,7 @@ void main() async {
     });
 
     test('when passed empty env value then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': ''},
       );
@@ -339,7 +339,7 @@ void main() async {
     test(
         'when passed several comma-separated env values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': '123,456'},
       );
@@ -349,7 +349,7 @@ void main() async {
     test(
         'when passed null value from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': null}),
       );
@@ -359,7 +359,7 @@ void main() async {
     test(
         'when passed empty array of strings from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': <String>[]}),
       );
@@ -369,7 +369,7 @@ void main() async {
     test(
         'when passed empty array of ints from config source then it reports a type error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': <int>[]}),
       );
@@ -384,7 +384,7 @@ void main() async {
     test(
         'when passed string array value from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({
           'many': ['123', '456']
@@ -396,7 +396,7 @@ void main() async {
     test(
         'when passed plain string value from config source then it is parsed into a single-element array',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': 'plain-string'}),
       );
@@ -406,7 +406,7 @@ void main() async {
     test(
         'when passed int array value from config source then it reports a type error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({
           'many': [123]
@@ -423,7 +423,7 @@ void main() async {
     test(
         'when passed several comma-separated values in a plain string from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': '123,456'}),
       );
@@ -440,7 +440,7 @@ void main() async {
     );
 
     test('when passed no values then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: [],
       );
@@ -449,7 +449,7 @@ void main() async {
 
     test('when passed a single arg value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123'],
       );
@@ -458,7 +458,7 @@ void main() async {
 
     test('when passed several arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123', '--many', '456'],
       );
@@ -468,7 +468,7 @@ void main() async {
     test(
         'when passed several comma-separated arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123,456'],
       );
@@ -476,7 +476,7 @@ void main() async {
     });
 
     test('when passed empty env value then it reports a parse error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': ''},
       );
@@ -491,7 +491,7 @@ void main() async {
     test(
         'when passed several comma-separated env values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': '123,456'},
       );
@@ -501,7 +501,7 @@ void main() async {
     test(
         'when passed null value from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': null}),
       );
@@ -511,7 +511,7 @@ void main() async {
     test(
         'when passed empty array of strings from config source then it reports a type error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': <String>[]}),
       );
@@ -526,7 +526,7 @@ void main() async {
     test(
         'when passed empty array of ints from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': <int>[]}),
       );
@@ -536,7 +536,7 @@ void main() async {
     test(
         'when passed int array value from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({
           'many': [123, 456]
@@ -548,7 +548,7 @@ void main() async {
     test(
         'when passed plain string value from config source then it reports a parse error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': 'plain-string'}),
       );
@@ -563,7 +563,7 @@ void main() async {
     test(
         'when passed string array value from config source then it reports a type error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({
           'many': ['123']
@@ -580,7 +580,7 @@ void main() async {
     test(
         'when passed several comma-separated values in a plain string from config source then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         configBroker: _TestConfigBroker({'many': '123,456'}),
       );
@@ -598,7 +598,7 @@ void main() async {
     );
 
     test('when passed no values then it produces the default value', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: [],
       );
@@ -607,7 +607,7 @@ void main() async {
 
     test('when passed a single arg value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123'],
       );
@@ -616,7 +616,7 @@ void main() async {
 
     test('when passed several arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123', '--many', '456'],
       );
@@ -626,7 +626,7 @@ void main() async {
     test(
         'when passed several comma-separated arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123,456'],
       );
@@ -634,7 +634,7 @@ void main() async {
     });
 
     test('when passed empty env value then it reports a parse error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': ''},
       );
@@ -649,7 +649,7 @@ void main() async {
     test(
         'when passed several comma-separated env values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': '123,456'},
       );
@@ -658,7 +658,7 @@ void main() async {
 
     test('when passed several arg and env values then args take precedence',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '12', '--many', '45'],
         env: <String, String>{'SERVERPOD_MANY': '123,456'},
@@ -678,7 +678,7 @@ void main() async {
     );
 
     test('when passed no values then it reports a parse error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: [],
       );
@@ -691,7 +691,7 @@ void main() async {
 
     test('when passed a single arg value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123'],
       );
@@ -700,7 +700,7 @@ void main() async {
 
     test('when passed several arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123', '--many', '456'],
       );
@@ -710,7 +710,7 @@ void main() async {
     test(
         'when passed several arg values using both regular name and alias '
         'then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123', '--alias-many', '456'],
       );
@@ -720,7 +720,7 @@ void main() async {
     test(
         'when passed several comma-separated arg values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', '123,456'],
       );
@@ -728,7 +728,7 @@ void main() async {
     });
 
     test('when passed empty env value then it reports a parse error', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': ''},
       );
@@ -743,7 +743,7 @@ void main() async {
     test(
         'when passed several comma-separated env values then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'SERVERPOD_MANY': '123,456'},
       );
@@ -760,7 +760,7 @@ void main() async {
     );
 
     test('when passed no value then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: [],
       );
@@ -768,7 +768,7 @@ void main() async {
     });
 
     test('when passed a valid value then it is parsed correctly', () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', 'foo'],
       );
@@ -777,7 +777,7 @@ void main() async {
 
     test('when passed a valid empty value then it is parsed correctly',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', ''],
       );
@@ -786,7 +786,7 @@ void main() async {
 
     test('when passed an invalid value as arg then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', 'wrong'],
       );
@@ -801,7 +801,7 @@ void main() async {
 
     test('when passed an invalid value as env var then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         env: <String, String>{'MANY': 'wrong'},
       );
@@ -817,7 +817,7 @@ void main() async {
 
     test('when passed a valid and an invalid value then it reports an error',
         () async {
-      final config = Configuration.resolve(
+      final config = Configuration.resolveNoExcept(
         options: [typedOpt],
         args: ['--many', 'foo', '--many', 'wrong'],
       );

--- a/test/config/file_options_test.dart
+++ b/test/config/file_options_test.dart
@@ -14,7 +14,7 @@ void main() async {
       );
 
       group('when passing arg that is non-existent', () {
-        final config = Configuration.resolve(
+        final config = Configuration.resolveNoExcept(
           options: [dirOpt],
           args: ['--folder', 'does-not-exist'],
         );
@@ -37,7 +37,7 @@ void main() async {
           await d.dir(existingDirName).create();
           dirPath = p.join(d.sandbox, existingDirName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [dirOpt],
             args: ['--folder', dirPath],
           );
@@ -61,7 +61,7 @@ void main() async {
           await d.file(existingFileName).create();
           filePath = p.join(d.sandbox, existingFileName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [dirOpt],
             args: ['--folder', filePath],
           );
@@ -87,7 +87,7 @@ void main() async {
       );
 
       group('when passing arg that is non-existent', () {
-        final config = Configuration.resolve(
+        final config = Configuration.resolveNoExcept(
           options: [dirOpt],
           args: ['--folder', 'does-not-exist'],
         );
@@ -112,7 +112,7 @@ void main() async {
           await d.dir(existingDirName).create();
           dirPath = p.join(d.sandbox, existingDirName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [dirOpt],
             args: ['--folder', dirPath],
           );
@@ -136,7 +136,7 @@ void main() async {
           await d.file(existingFileName).create();
           filePath = p.join(d.sandbox, existingFileName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [dirOpt],
             args: ['--folder', filePath],
           );
@@ -162,7 +162,7 @@ void main() async {
       );
 
       group('when passing arg that is non-existent', () {
-        final config = Configuration.resolve(
+        final config = Configuration.resolveNoExcept(
           options: [dirOpt],
           args: ['--folder', 'does-not-exist'],
         );
@@ -185,7 +185,7 @@ void main() async {
           await d.dir(existingDirName).create();
           dirPath = p.join(d.sandbox, existingDirName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [dirOpt],
             args: ['--folder', dirPath],
           );
@@ -211,7 +211,7 @@ void main() async {
           await d.file(existingFileName).create();
           filePath = p.join(d.sandbox, existingFileName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [dirOpt],
             args: ['--folder', filePath],
           );
@@ -239,7 +239,7 @@ void main() async {
       );
 
       group('when passing arg that is non-existent', () {
-        final config = Configuration.resolve(
+        final config = Configuration.resolveNoExcept(
           options: [fileOpt],
           args: ['--file', 'does-not-exist'],
         );
@@ -262,7 +262,7 @@ void main() async {
           await d.dir(existingDirName).create();
           dirPath = p.join(d.sandbox, existingDirName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [fileOpt],
             args: ['--file', dirPath],
           );
@@ -288,7 +288,7 @@ void main() async {
           await d.file(existingFileName).create();
           filePath = p.join(d.sandbox, existingFileName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [fileOpt],
             args: ['--file', filePath],
           );
@@ -312,7 +312,7 @@ void main() async {
       );
 
       group('when passing arg that is non-existent', () {
-        final config = Configuration.resolve(
+        final config = Configuration.resolveNoExcept(
           options: [fileOpt],
           args: ['--file', 'does-not-exist'],
         );
@@ -337,7 +337,7 @@ void main() async {
           await d.dir(existingDirName).create();
           dirPath = p.join(d.sandbox, existingDirName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [fileOpt],
             args: ['--file', dirPath],
           );
@@ -363,7 +363,7 @@ void main() async {
           await d.file(existingFileName).create();
           filePath = p.join(d.sandbox, existingFileName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [fileOpt],
             args: ['--file', filePath],
           );
@@ -387,7 +387,7 @@ void main() async {
       );
 
       group('when passing arg that is non-existent', () {
-        final config = Configuration.resolve(
+        final config = Configuration.resolveNoExcept(
           options: [fileOpt],
           args: ['--file', 'does-not-exist'],
         );
@@ -410,7 +410,7 @@ void main() async {
           await d.dir(existingDirName).create();
           dirPath = p.join(d.sandbox, existingDirName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [fileOpt],
             args: ['--file', dirPath],
           );
@@ -436,7 +436,7 @@ void main() async {
           await d.file(existingFileName).create();
           filePath = p.join(d.sandbox, existingFileName);
 
-          config = Configuration.resolve(
+          config = Configuration.resolveNoExcept(
             options: [fileOpt],
             args: ['--file', filePath],
           );


### PR DESCRIPTION
When `Configuration` is used without `BetterCommand/Runner` its default behavior should be to throw an informative exception on usage errors, rather then expecting the caller to explicitly check for errors and always provide custom error handling. (This also mirrors the behavior of `args` package `ArgParser`.) The old behavior is still available but now opt-in.

The thrown `UsageException` contains the error messages produced by the options resolution, and the usage help text. This exception behavior is consistent with the `BetterCommand/Runner`.

This is a breaking change for direct uses of `Configuration`, but not for uses of `BetterCommand/Runner`.

Depends on PR #47 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration resolution method that does not throw exceptions, allowing for more flexible error handling.
  - Introduced a utility for improved formatting of configuration error messages.

- **Bug Fixes**
  - Improved error reporting for invalid option definitions and configuration errors.

- **Refactor**
  - Renamed error classes and updated error handling to use more descriptive types.
  - Adjusted regular expression matching for duration parsing to improve accuracy.
  - Modified configuration resolution logic to separate error throwing from resolution.

- **Tests**
  - Updated and expanded test coverage to reflect new error handling behaviors and exception types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->