### PR TITLE
feat!: Add `topLevelResults` to `onBeforeRunCommand`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/
+.asdf
+.tool-versions

--- a/lib/src/better_command_runner/better_command_runner.dart
+++ b/lib/src/better_command_runner/better_command_runner.dart
@@ -7,7 +7,10 @@ import 'package:cli_tools/config.dart';
 import 'package:cli_tools/src/config/output_formatting.dart';
 
 /// A function type for executing code before running a command.
-typedef OnBeforeRunCommand = Future<void> Function(BetterCommandRunner runner);
+typedef OnBeforeRunCommand = Future<void> Function(
+  BetterCommandRunner runner,
+  ArgResults topLevelResults,
+);
 
 /// A proxy for user-provided functions for passing specific log messages.
 ///
@@ -293,7 +296,7 @@ class BetterCommandRunner<O extends OptionDefinition, T>
       }),
     );
 
-    await _onBeforeRunCommand?.call(this);
+    await _onBeforeRunCommand?.call(this, topLevelResults);
 
     try {
       return await super.runCommand(topLevelResults);

--- a/test/better_command_runner/command_test.dart
+++ b/test/better_command_runner/command_test.dart
@@ -105,7 +105,7 @@ void main() {
       runner = BetterCommandRunner(
         'test',
         'this is a test cli',
-        onBeforeRunCommand: (_) => Future(() => calls.add('callback')),
+        onBeforeRunCommand: (_, __) => Future(() => calls.add('callback')),
       )..addCommand(mockCommand);
 
       var args = [MockCommand.commandName];


### PR DESCRIPTION
While looking at https://github.com/serverpod/serverpod/issues/3770, we download templates in the `onBeforeRunCommand` callback. Since we'd need to check which command is currently being run in order to decide whether we need to download templates or not, we need access to the `topLevelResults` to check the parsed arguments.

Since this change is breaking, we'd also consider parsing the results in the callback in the context of the above mentioned issue. This PR is mainly a discussion on whether this breaking change makes sense and does it enough add value to our users to warrent a breaking change as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository settings to ignore `.asdf` and `.tool-versions` files.
* **Refactor**
  * Adjusted callback signatures to accept an additional argument for improved compatibility.
* **Tests**
  * Updated test callbacks to match the revised callback signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->