### PR TITLE
docs(config): Corrected BetterCommand refs in README for patch 0.7.1

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.7.1
+- docs: Corrected BetterCommand references and links in README
+
 ## 0.7.0
 - feat: Moved out the `config` library from the `cli_tools` package and into its own package, to be published as `config` on pub.dev.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -55,7 +55,8 @@ enabling direct use of the new features.
 
 It achieves complete compatibility with the original package with the exception
 of addCommand(), which you can replace with
-[`BetterCommandRunner`](lib/src/better_command_runner/better_command_runner.dart).
+[`BetterCommandRunner`](../cli_tools/lib/src/better_command_runner/better_command_runner.dart)
+from the [`cli_tools package`](https://pub.dev/packages/cli_tools).
 
 - **Compatibility**: The `ConfigParser` implements the same interface as
   `ArgParser`, and returns a `ConfigResults` object that implements `ArgResults`.
@@ -70,7 +71,7 @@ of addCommand(), which you can replace with
 
 - **Key Differences**:
   - The `addCommand()` method is not supported
-  (see [`BetterCommandRunner`](lib/src/better_command_runner/better_command_runner.dart) instead)
+  (see [`BetterCommandRunner`](../cli_tools/lib/src/better_command_runner/better_command_runner.dart) instead)
   - All validation is performed up-front with consistent error messages
   - The parser supports additional configuration sources (environment variables, config files)
 
@@ -296,9 +297,10 @@ from the `args` package.
 To use the config library with these, they need to be subclassed
 to modify the use of `ArgParser` and introduce `Configuration`. This has
 already been done for you, with the `BetterCommand` and `BetterCommandRunner`
-classes in the `better_command_runner` library in this package.
+classes in the `better_command_runner` library in the
+[`cli_tools package`](https://pub.dev/packages/cli_tools).
 
-See the full example [example/config_simple_example.dart](example/config_simple_example.dart).
+See the full example [cli_tools/example/simple_command_example.dart](../cli_tools/example/simple_command_example.dart).
 
 ## Using configuration files
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -55,7 +55,7 @@ enabling direct use of the new features.
 
 It achieves complete compatibility with the original package with the exception
 of addCommand(), which you can replace with
-[`BetterCommandRunner`](../cli_tools/lib/src/better_command_runner/better_command_runner.dart)
+[`BetterCommandRunner`](https://github.com/serverpod/cli_tools/blob/pkg-split/packages/cli_tools/lib/src/better_command_runner/better_command_runner.dart)
 from the [`cli_tools package`](https://pub.dev/packages/cli_tools).
 
 - **Compatibility**: The `ConfigParser` implements the same interface as
@@ -71,7 +71,7 @@ from the [`cli_tools package`](https://pub.dev/packages/cli_tools).
 
 - **Key Differences**:
   - The `addCommand()` method is not supported
-  (see [`BetterCommandRunner`](../cli_tools/lib/src/better_command_runner/better_command_runner.dart) instead)
+  (see [`BetterCommandRunner`](https://github.com/serverpod/cli_tools/blob/pkg-split/packages/cli_tools/lib/src/better_command_runner/better_command_runner.dart) instead)
   - All validation is performed up-front with consistent error messages
   - The parser supports additional configuration sources (environment variables, config files)
 
@@ -300,7 +300,7 @@ already been done for you, with the `BetterCommand` and `BetterCommandRunner`
 classes in the `better_command_runner` library in the
 [`cli_tools package`](https://pub.dev/packages/cli_tools).
 
-See the full example [cli_tools/example/simple_command_example.dart](../cli_tools/example/simple_command_example.dart).
+See the full example [cli_tools/example/simple_command_example.dart](https://github.com/serverpod/cli_tools/blob/pkg-split/packages/cli_tools/example/simple_command_example.dart).
 
 ## Using configuration files
 

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: config
-version: 0.7.0
+version: 0.7.1
 description: A package for parsing command-line arguments and configuration files.
 repository: https://github.com/serverpod/cli_tools
 issue_tracker: https://github.com/serverpod/cli_tools/issues


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify and correct references to BetterCommandRunner and BetterCommand, including import paths and example usage.
  * Added explicit mention and links to the cli_tools package.
  * Updated changelog to document these documentation improvements.

* **Chores**
  * Bumped package version to 0.7.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->