### PR TITLE
revert: Do not force strict generic types

### DIFF
--- a/packages/cli_tools/analysis_options.yaml
+++ b/packages/cli_tools/analysis_options.yaml
@@ -1,5 +1,12 @@
 include: package:serverpod_lints/cli.yaml
 
+analyzer:
+  language:
+    strict-raw-types: false
+  errors:
+    inference_failure_on_instance_creation: ignore
+    inference_failure_on_function_invocation: ignore
+
 linter:
   rules:
     prefer_relative_imports: true

--- a/packages/cli_tools/example/main.dart
+++ b/packages/cli_tools/example/main.dart
@@ -2,7 +2,7 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 
 Future<int> main(final List<String> args) async {
-  final commandRunner = BetterCommandRunner<OptionDefinition<Object>, void>(
+  final commandRunner = BetterCommandRunner(
     'example',
     'Example CLI command',
     globalOptions: [

--- a/packages/cli_tools/example/simple_command_example.dart
+++ b/packages/cli_tools/example/simple_command_example.dart
@@ -14,7 +14,7 @@ import 'package:config/config.dart';
 /// INTERVAL=1s dart run example/simple_command_example.dart show
 /// ```
 Future<int> main(final List<String> args) async {
-  final commandRunner = BetterCommandRunner<OptionDefinition<Object>, void>(
+  final commandRunner = BetterCommandRunner(
     'example',
     'Example CLI command',
   );

--- a/packages/cli_tools/lib/src/better_command_runner/better_command_runner.dart
+++ b/packages/cli_tools/lib/src/better_command_runner/better_command_runner.dart
@@ -6,8 +6,7 @@ import 'package:args/command_runner.dart';
 import 'package:config/config.dart';
 
 /// A function type for executing code before running a command.
-typedef OnBeforeRunCommand<O extends OptionDefinition<Object>, T> = Future<void>
-    Function(BetterCommandRunner<O, T> runner);
+typedef OnBeforeRunCommand = Future<void> Function(BetterCommandRunner runner);
 
 /// A proxy for user-provided functions for passing specific log messages.
 ///
@@ -55,7 +54,7 @@ typedef OnAnalyticsEvent = void Function(String event);
 /// The [BetterCommandRunner] class uses the config library to provide
 /// a more enhanced command line interface for running commands and handling
 /// command line arguments, environment variables, and configuration.
-class BetterCommandRunner<O extends OptionDefinition<Object>, T>
+class BetterCommandRunner<O extends OptionDefinition, T>
     extends CommandRunner<T> {
   /// Process exit code value for command not found -
   /// The specified command was not found or couldn't be located.
@@ -63,7 +62,7 @@ class BetterCommandRunner<O extends OptionDefinition<Object>, T>
 
   final MessageOutput? _messageOutput;
   final SetLogLevel? _setLogLevel;
-  final OnBeforeRunCommand<O, T>? _onBeforeRunCommand;
+  final OnBeforeRunCommand? _onBeforeRunCommand;
   OnAnalyticsEvent? _onAnalyticsEvent;
 
   /// The environment variables used for configuration resolution.
@@ -144,7 +143,7 @@ class BetterCommandRunner<O extends OptionDefinition<Object>, T>
     final MessageOutput? messageOutput =
         const MessageOutput(usageLogger: print),
     final SetLogLevel? setLogLevel,
-    final OnBeforeRunCommand<O, T>? onBeforeRunCommand,
+    final OnBeforeRunCommand? onBeforeRunCommand,
     final OnAnalyticsEvent? onAnalyticsEvent,
     final int? wrapTextColumn,
     final List<O>? globalOptions,

--- a/packages/cli_tools/lib/src/documentation_generator/documentation_generator.dart
+++ b/packages/cli_tools/lib/src/documentation_generator/documentation_generator.dart
@@ -1,9 +1,7 @@
-import 'package:config/config.dart' show OptionDefinition;
-
 import '../../better_command_runner.dart' show BetterCommandRunner;
 
 class CommandDocumentationGenerator {
-  final BetterCommandRunner<OptionDefinition<Object>, void> commandRunner;
+  final BetterCommandRunner commandRunner;
 
   CommandDocumentationGenerator(this.commandRunner);
 

--- a/packages/cli_tools/test/better_command_runner/analytics_test.dart
+++ b/packages/cli_tools/test/better_command_runner/analytics_test.dart
@@ -2,12 +2,11 @@ import 'dart:async';
 
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
-import 'package:config/config.dart' show OptionDefinition;
 import 'package:test/test.dart';
 
 import '../test_utils/test_utils.dart' show flushEventQueue;
 
-class MockCommand extends Command<void> {
+class MockCommand extends Command {
   static String commandName = 'mock-command';
 
   @override
@@ -28,7 +27,7 @@ class MockCommand extends Command<void> {
   }
 }
 
-class CompletableMockCommand extends Command<void> {
+class CompletableMockCommand extends Command {
   static String commandName = 'completable-mock-command';
 
   @override
@@ -54,9 +53,9 @@ class CompletableMockCommand extends Command<void> {
 }
 
 void main() {
-  late BetterCommandRunner<OptionDefinition<Object>, void> runner;
+  late BetterCommandRunner runner;
   group('Given runner with null onAnalyticsEvent callback', () {
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'this is a test cli',
       onAnalyticsEvent: null,
@@ -76,7 +75,7 @@ void main() {
   });
 
   group('Given runner with onAnalyticsEvent callback defined', () {
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'this is a test cli',
       onAnalyticsEvent: (final event) {},
@@ -95,7 +94,7 @@ void main() {
   group('Given runner with analytics enabled', () {
     List<String> events = [];
     setUp(() {
-      runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+      runner = BetterCommandRunner(
         'test',
         'this is a test cli',
         onAnalyticsEvent: (final event) => events.add(event),
@@ -208,7 +207,7 @@ void main() {
   group('Given runner with registered command and analytics enabled', () {
     List<String> events = [];
     setUp(() {
-      runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+      runner = BetterCommandRunner(
         'test',
         'this is a test cli',
         onAnalyticsEvent: (final event) => events.add(event),
@@ -273,7 +272,7 @@ void main() {
     late CompletableMockCommand command;
     setUp(() {
       command = CompletableMockCommand();
-      runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+      runner = BetterCommandRunner(
         'test',
         'this is a test cli',
         onAnalyticsEvent: (final event) => events.add(event),

--- a/packages/cli_tools/test/better_command_runner/better_command_test.dart
+++ b/packages/cli_tools/test/better_command_runner/better_command_test.dart
@@ -16,7 +16,7 @@ enum BespokeGlobalOption<V extends Object> implements OptionDefinition<V> {
   final ConfigOptionBase<V> option;
 }
 
-class MockCommand extends BetterCommand<OptionDefinition<Object>, void> {
+class MockCommand extends BetterCommand {
   static String commandName = 'mock-command';
 
   MockCommand({super.messageOutput})
@@ -38,9 +38,7 @@ class MockCommand extends BetterCommand<OptionDefinition<Object>, void> {
   Future<void> run() async {}
 
   @override
-  FutureOr<void>? runWithConfig(
-    final Configuration<OptionDefinition<Object>> commandConfig,
-  ) {
+  FutureOr? runWithConfig(final Configuration<OptionDefinition> commandConfig) {
     throw UnimplementedError();
   }
 }
@@ -58,7 +56,7 @@ void main() {
     final betterCommand = MockCommand(
       messageOutput: messageOutput,
     );
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'test project',
       onAnalyticsEvent: (final e) => analyticsEvents.add(e),
@@ -99,7 +97,7 @@ void main() {
         'then help analytics is sent', () async {
       await runner.run(['--help']);
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 100));
       expect(analyticsEvents, hasLength(1));
       expect(analyticsEvents.single, 'help');
     });
@@ -109,7 +107,7 @@ void main() {
         'then help analytics is sent', () async {
       await runner.run(['help']);
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 100));
       expect(analyticsEvents, hasLength(1));
       expect(analyticsEvents.single, 'help');
     });
@@ -119,7 +117,7 @@ void main() {
         'then subcommand analytics is sent', () async {
       await runner.run([MockCommand.commandName]);
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 100));
       expect(analyticsEvents, hasLength(1));
       expect(analyticsEvents.single, 'mock-command');
     });
@@ -129,7 +127,7 @@ void main() {
         'then invalid command analytics is sent', () async {
       await runner.run(['no-such-command']).catchError((final _) {});
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 100));
       expect(analyticsEvents, hasLength(1));
       expect(analyticsEvents.single, 'invalid');
     });
@@ -140,7 +138,7 @@ void main() {
         'then subcommand analytics is not sent', () async {
       await runner.run([MockCommand.commandName, '--no-analytics']);
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 100));
       expect(analyticsEvents, isEmpty);
     });
   });
@@ -157,7 +155,7 @@ void main() {
     final betterCommand = MockCommand(
       messageOutput: messageOutput,
     );
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'test project',
       onAnalyticsEvent: (final e) => analyticsEvents.add(e),
@@ -207,7 +205,7 @@ void main() {
     final betterCommand = MockCommand(
       messageOutput: messageOutput,
     );
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'test project',
       messageOutput: messageOutput,
@@ -256,7 +254,7 @@ void main() {
     final betterCommand = MockCommand(
       messageOutput: messageOutput,
     );
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'test project',
       globalOptions: BespokeGlobalOption.values,

--- a/packages/cli_tools/test/better_command_runner/command_test.dart
+++ b/packages/cli_tools/test/better_command_runner/command_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
-import 'package:config/config.dart' show OptionDefinition;
 import 'package:test/test.dart';
 
 class MockCommand extends Command<void> {
@@ -34,7 +33,7 @@ class MockCommand extends Command<void> {
 }
 
 void main() {
-  late BetterCommandRunner<OptionDefinition<Object>, void> runner;
+  late BetterCommandRunner runner;
   late MockCommand mockCommand;
   group('Given runner with registered command', () {
     setUp(() {

--- a/packages/cli_tools/test/better_command_runner/default_flags_test.dart
+++ b/packages/cli_tools/test/better_command_runner/default_flags_test.dart
@@ -1,10 +1,9 @@
 import 'package:cli_tools/better_command_runner.dart';
-import 'package:config/config.dart' show OptionDefinition;
 import 'package:test/test.dart';
 
 void main() {
   group('Given BetterCommandRunner runner with onAnalyticsEvent', () {
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'test description',
       onAnalyticsEvent: (final event) {},

--- a/packages/cli_tools/test/better_command_runner/exit_exceptions_test.dart
+++ b/packages/cli_tools/test/better_command_runner/exit_exceptions_test.dart
@@ -1,9 +1,8 @@
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
-import 'package:config/config.dart' show OptionDefinition;
 import 'package:test/test.dart';
 
-class MockCommand extends Command<void> {
+class MockCommand extends Command {
   static String commandName = 'mock-command';
 
   @override
@@ -29,10 +28,8 @@ class MockCommand extends Command<void> {
 
 void main() {
   group('Given runner with registered command', () {
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
-      'test',
-      'this is a test cli',
-    )..addCommand(MockCommand());
+    final runner = BetterCommandRunner('test', 'this is a test cli')
+      ..addCommand(MockCommand());
 
     test(
       'when running with unknown command then UsageException is thrown.',

--- a/packages/cli_tools/test/better_command_runner/logging_test.dart
+++ b/packages/cli_tools/test/better_command_runner/logging_test.dart
@@ -1,9 +1,8 @@
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
-import 'package:config/config.dart' show OptionDefinition;
 import 'package:test/test.dart';
 
-class MockCommand extends Command<void> {
+class MockCommand extends Command {
   static String commandName = 'mock-command';
 
   @override
@@ -31,7 +30,7 @@ void main() {
   group('Given runner with registered command and logging monitor', () {
     final errors = <String>[];
     final infos = <String>[];
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'this is a test cli',
       messageOutput: MessageOutput(

--- a/packages/cli_tools/test/better_command_runner/parse_log_level_test.dart
+++ b/packages/cli_tools/test/better_command_runner/parse_log_level_test.dart
@@ -1,9 +1,8 @@
 import 'package:args/command_runner.dart';
 import 'package:cli_tools/better_command_runner.dart';
-import 'package:config/config.dart' show OptionDefinition;
 import 'package:test/test.dart';
 
-class MockCommand extends Command<void> {
+class MockCommand extends Command {
   static String commandName = 'mock-command';
 
   @override
@@ -25,7 +24,7 @@ void main() {
     logLevel = null;
   });
   group('Given runner with setLogLevel callback', () {
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'this is a test cli',
       messageOutput: const MessageOutput(),
@@ -93,7 +92,7 @@ void main() {
   });
 
   group('Given runner with setLogLevel callback and registered command', () {
-    final runner = BetterCommandRunner<OptionDefinition<Object>, void>(
+    final runner = BetterCommandRunner(
       'test',
       'this is a test cli',
       setLogLevel: ({

--- a/packages/cli_tools/test/documentation_generator/generate_markdown_test.dart
+++ b/packages/cli_tools/test/documentation_generator/generate_markdown_test.dart
@@ -5,7 +5,7 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart' show Configuration, OptionDefinition;
 import 'package:test/test.dart';
 
-class AddSpiceCommand extends Command<void> {
+class AddSpiceCommand extends Command {
   @override
   final String name = 'add';
 
@@ -21,7 +21,7 @@ class AddSpiceCommand extends Command<void> {
   void run() {}
 }
 
-class RemoveSpiceCommand extends Command<void> {
+class RemoveSpiceCommand extends Command {
   @override
   final String name = 'remove';
 
@@ -37,7 +37,7 @@ class RemoveSpiceCommand extends Command<void> {
   void run() {}
 }
 
-class AddVegetableCommand extends Command<void> {
+class AddVegetableCommand extends Command {
   @override
   final String name = 'add';
 
@@ -52,7 +52,7 @@ class AddVegetableCommand extends Command<void> {
   void run() {}
 }
 
-class SpiceCommand extends BetterCommand<OptionDefinition<Object>, void> {
+class SpiceCommand extends BetterCommand {
   @override
   final String name = 'spice';
 
@@ -68,14 +68,12 @@ class SpiceCommand extends BetterCommand<OptionDefinition<Object>, void> {
   void run() {}
 
   @override
-  FutureOr<void>? runWithConfig(
-    final Configuration<OptionDefinition<Object>> commandConfig,
-  ) {
+  FutureOr? runWithConfig(final Configuration<OptionDefinition> commandConfig) {
     throw UnimplementedError();
   }
 }
 
-class VegetableCommand extends BetterCommand<OptionDefinition<Object>, void> {
+class VegetableCommand extends BetterCommand {
   @override
   final String name = 'vegetable';
 
@@ -90,9 +88,7 @@ class VegetableCommand extends BetterCommand<OptionDefinition<Object>, void> {
   void run() {}
 
   @override
-  FutureOr<void>? runWithConfig(
-    final Configuration<OptionDefinition<Object>> commandConfig,
-  ) {
+  FutureOr? runWithConfig(final Configuration<OptionDefinition> commandConfig) {
     throw UnimplementedError();
   }
 }
@@ -102,12 +98,10 @@ void main() {
     late Map<String, String> output;
 
     setUpAll(() async {
-      final commandRunner = BetterCommandRunner<OptionDefinition<Object>, void>(
-        'cookcli',
-        'A cli to create wonderful dishes.',
-      )
-        ..addCommand(SpiceCommand())
-        ..addCommand(VegetableCommand());
+      final commandRunner =
+          BetterCommandRunner('cookcli', 'A cli to create wonderful dishes.')
+            ..addCommand(SpiceCommand())
+            ..addCommand(VegetableCommand());
       final generator = CommandDocumentationGenerator(commandRunner);
       output = generator.generateMarkdown();
     });

--- a/packages/cli_tools/test/pub_api_client_test.dart
+++ b/packages/cli_tools/test/pub_api_client_test.dart
@@ -14,7 +14,7 @@ MockClient createMockClient({
   return MockClient((final request) {
     if (request.method != 'GET') throw NoSuchMethodError;
     return Future<http.Response>(() async {
-      await Future<void>.delayed(responseDelay);
+      await Future.delayed(responseDelay);
       return http.Response(body, status);
     });
   });

--- a/packages/cli_tools/test/test_utils/mock_stdin.dart
+++ b/packages/cli_tools/test/test_utils/mock_stdin.dart
@@ -159,7 +159,7 @@ class MockStdin implements Stdin {
   }
 
   @override
-  Future<dynamic> pipe(final StreamConsumer<List<int>> streamConsumer) {
+  Future pipe(final StreamConsumer<List<int>> streamConsumer) {
     throw UnimplementedError();
   }
 

--- a/packages/cli_tools/test/test_utils/mock_stdout.dart
+++ b/packages/cli_tools/test/test_utils/mock_stdout.dart
@@ -25,20 +25,20 @@ class MockStdout implements Stdout {
   }
 
   @override
-  Future<dynamic> addStream(final Stream<List<int>> stream) {
+  Future addStream(final Stream<List<int>> stream) {
     throw UnimplementedError();
   }
 
   @override
-  Future<dynamic> close() {
+  Future close() {
     return Future.value();
   }
 
   @override
-  Future<dynamic> get done => Future.value();
+  Future get done => Future.value();
 
   @override
-  Future<dynamic> flush() {
+  Future flush() {
     return Future.value();
   }
 
@@ -67,7 +67,7 @@ class MockStdout implements Stdout {
   }
 
   @override
-  void writeAll(final Iterable<Object?> objects, [final String sep = '']) {
+  void writeAll(final Iterable objects, [final String sep = '']) {
     _buffer.writeAll(objects, sep);
   }
 

--- a/packages/cli_tools/test/test_utils/prompts/option_matcher.dart
+++ b/packages/cli_tools/test/test_utils/prompts/option_matcher.dart
@@ -12,7 +12,7 @@ class _EqualsAllOptionsMatcher extends Matcher {
   _EqualsAllOptionsMatcher(this._expected);
 
   @override
-  bool matches(final dynamic item, final Map<dynamic, dynamic> matchState) {
+  bool matches(final dynamic item, final Map matchState) {
     if (item is! List<Option>) {
       return false;
     }
@@ -39,7 +39,7 @@ class _EqualsAllOptionsMatcher extends Matcher {
   Description describeMismatch(
     final dynamic item,
     final Description mismatchDescription,
-    final Map<dynamic, dynamic> matchState,
+    final Map matchState,
     final bool verbose,
   ) {
     if (item is! List<Option>) {
@@ -68,7 +68,7 @@ class _EqualsOptionMatcher extends Matcher {
   _EqualsOptionMatcher(this._expected);
 
   @override
-  bool matches(final dynamic item, final Map<dynamic, dynamic> matchState) {
+  bool matches(final dynamic item, final Map matchState) {
     if (item is! Option) {
       return false;
     }
@@ -85,7 +85,7 @@ class _EqualsOptionMatcher extends Matcher {
   Description describeMismatch(
     final dynamic item,
     final Description mismatchDescription,
-    final Map<dynamic, dynamic> matchState,
+    final Map matchState,
     final bool verbose,
   ) {
     if (item is! Option) {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -90,7 +90,7 @@ that shows how to create a set of options for a particular command as an _enum_.
 ```dart
 import 'package:config/config.dart';
 
-enum LogOption<V extends Object> implements OptionDefinition<V> {
+enum LogOption<V> implements OptionDefinition<V> {
   limit(IntOption(
     argName: 'limit',
     helpText: 'The maximum number of log records to fetch.',

--- a/packages/config/analysis_options.yaml
+++ b/packages/config/analysis_options.yaml
@@ -1,5 +1,13 @@
 include: package:serverpod_lints/cli.yaml
 
+analyzer:
+  language:
+    strict-raw-types: false
+  errors:
+    inference_failure_on_instance_creation: ignore
+    inference_failure_on_function_invocation: ignore
+    inference_failure_on_untyped_parameter: ignore
+
 linter:
   rules:
     prefer_relative_imports: true

--- a/packages/config/example/config_file_example.dart
+++ b/packages/config/example/config_file_example.dart
@@ -40,7 +40,7 @@ Future<int> main(final List<String> args) async {
   return 0;
 }
 
-enum TimeSeriesOption<V extends Object> implements OptionDefinition<V> {
+enum TimeSeriesOption<V> implements OptionDefinition<V> {
   configFile(FileOption(
     argName: 'config',
     envName: 'CONFIG_FILE',

--- a/packages/config/example/main.dart
+++ b/packages/config/example/main.dart
@@ -41,7 +41,7 @@ int main(final List<String> args) {
 ///
 /// The enum approach is more distinct and type safe.
 /// The list approach is more dynamic and permits non-const initialization.
-enum TimeSeriesOption<V extends Object> implements OptionDefinition<V> {
+enum TimeSeriesOption<V> implements OptionDefinition<V> {
   until(DateTimeOption(
     argName: 'until',
     envName: 'SERIES_UNTIL', // can also be specified as environment variable

--- a/packages/config/lib/src/config/configuration.dart
+++ b/packages/config/lib/src/config/configuration.dart
@@ -17,7 +17,7 @@ import 'source_type.dart';
 /// import 'dart:io' show Platform;
 /// import 'package:config/config.dart';
 ///
-/// enum MyAppOption<V extends Object> implements OptionDefinition<V> {
+/// enum MyAppOption<V> implements OptionDefinition<V> {
 ///   username(StringOption(
 ///     argName: 'username',
 ///     envName: 'USERNAME',
@@ -201,7 +201,7 @@ class Configuration<O extends OptionDefinition> {
   /// identified by name, position, or key.
   ///
   /// Returns `null` if the option is not found or is not set.
-  V? findValueOf<V extends Object>({
+  V? findValueOf<V>({
     final String? enumName,
     final String? argName,
     final int? argPos,
@@ -238,7 +238,7 @@ class Configuration<O extends OptionDefinition> {
   /// [StateError] is thrown. See also [optionalValue].
   ///
   /// Throws [ArgumentError] if the option is unknown.
-  V value<V extends Object>(final OptionDefinition<V> option) {
+  V value<V>(final OptionDefinition<V> option) {
     if (!(option.option.mandatory ||
         option.option.fromDefault != null ||
         option.option.defaultsTo != null)) {
@@ -257,7 +257,7 @@ class Configuration<O extends OptionDefinition> {
   /// Returns `null` if the option is not set.
   ///
   /// Throws [ArgumentError] if the option is unknown.
-  V? optionalValue<V extends Object>(final OptionDefinition<V> option) {
+  V? optionalValue<V>(final OptionDefinition<V> option) {
     final resolution = _getOptionResolution(option);
 
     return resolution.value as V?;
@@ -270,9 +270,7 @@ class Configuration<O extends OptionDefinition> {
     return resolution.source;
   }
 
-  OptionResolution _getOptionResolution<V extends Object>(
-    final OptionDefinition<V> option,
-  ) {
+  OptionResolution _getOptionResolution<V>(final OptionDefinition<V> option) {
     if (!_options.contains(option)) {
       throw ArgumentError(
           '${option.qualifiedString()} is not part of this configuration');

--- a/packages/config/lib/src/config/option_resolution.dart
+++ b/packages/config/lib/src/config/option_resolution.dart
@@ -1,6 +1,6 @@
 import 'source_type.dart';
 
-final class OptionResolution<V extends Object> {
+final class OptionResolution<V> {
   final String? stringValue;
   final V? value;
   final String? error;

--- a/packages/config/lib/src/config/option_types.dart
+++ b/packages/config/lib/src/config/option_types.dart
@@ -161,8 +161,7 @@ class EnumOption<E extends Enum> extends ConfigOptionBase<E> {
 ///
 /// If the input is outside the specified limits
 /// the validation throws a [FormatException].
-class ComparableValueOption<V extends Comparable<Object>>
-    extends ConfigOptionBase<V> {
+class ComparableValueOption<V extends Comparable> extends ConfigOptionBase<V> {
   final V? min;
   final V? max;
 

--- a/packages/config/lib/src/config/options.dart
+++ b/packages/config/lib/src/config/options.dart
@@ -19,7 +19,7 @@ import 'source_type.dart';
 /// The typical usage pattern is to use an enum with the options
 /// and implement this interface like so:
 /// ```dart
-/// enum MyAppOption<V extends Object> implements OptionDefinition<V> {
+/// enum MyAppOption<V> implements OptionDefinition<V> {
 ///   username(StringOption(
 ///     argName: 'username',
 ///     envName: 'USERNAME',
@@ -34,7 +34,7 @@ import 'source_type.dart';
 ///
 /// See [ConfigOptionBase] for more information on options,
 /// and [Configuration] on how to initialize the configuration.
-abstract interface class OptionDefinition<V extends Object> {
+abstract interface class OptionDefinition<V> {
   ConfigOptionBase<V> get option;
 }
 
@@ -162,7 +162,7 @@ abstract class ValueParser<V> {
 /// The typical usage pattern is to use an enum with the options
 /// and instantiate subclasses of [ConfigOptionBase] like so:
 /// ```dart
-/// enum MyAppOption<V extends Object> implements OptionDefinition<V> {
+/// enum MyAppOption<V> implements OptionDefinition<V> {
 ///   username(StringOption(
 ///     argName: 'username',
 ///     envName: 'USERNAME',
@@ -176,8 +176,7 @@ abstract class ValueParser<V> {
 /// ```
 ///
 /// See [Configuration] on how to initialize the configuration.
-abstract class ConfigOptionBase<V extends Object>
-    implements OptionDefinition<V> {
+abstract class ConfigOptionBase<V> implements OptionDefinition<V> {
   final ValueParser<V> valueParser;
 
   final String? argName;
@@ -450,7 +449,7 @@ abstract class ConfigOptionBase<V extends Object>
     }
     if (value is V) {
       return OptionResolution(
-        value: value,
+        value: value as V,
         source: ValueSourceType.config,
       );
     }

--- a/packages/config/test/config/args_compatibility/command_runner_test.dart
+++ b/packages/config/test/config/args_compatibility/command_runner_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_escaping_inner_quotes, prefer_final_locals, prefer_final_in_for_each, prefer_final_parameters, strict_raw_type
+// ignore_for_file: avoid_escaping_inner_quotes, prefer_final_locals, prefer_final_in_for_each, prefer_final_parameters
 
 @Skip('CommandRunner not supported')
 library;

--- a/packages/config/test/config/args_compatibility/test_utils.dart
+++ b/packages/config/test/config/args_compatibility/test_utils.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: prefer_final_parameters, strict_raw_type
+// ignore_for_file: prefer_final_parameters
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';

--- a/packages/config/test/config/configuration_test.dart
+++ b/packages/config/test/config/configuration_test.dart
@@ -12,10 +12,11 @@ void main() async {
     test('when preparing for parsing then throws exception', () async {
       expect(
         () => [projectIdOpt].prepareForParsing(parser),
-        throwsA(isA<OptionDefinitionError>().having(
-          (final e) => e.message,
-          'message',
-          "An argument option can't have an abbreviation but not a full name",
+        throwsA(allOf(
+          isA<OptionDefinitionError>(),
+          (final e) => e.toString().contains(
+                "An argument option can't have an abbreviation but not a full name",
+              ),
         )),
       );
     });
@@ -31,10 +32,11 @@ void main() async {
     test('when preparing for parsing then throws exception', () async {
       expect(
         () => [projectIdOpt].prepareForParsing(parser),
-        throwsA(isA<OptionDefinitionError>().having(
-          (final e) => e.message,
-          'message',
-          "Mandatory options can't have default values",
+        throwsA(allOf(
+          isA<OptionDefinitionError>(),
+          (final e) => e
+              .toString()
+              .contains("Mandatory options can't have default values"),
         )),
       );
     });
@@ -53,10 +55,11 @@ void main() async {
     test('when preparing for parsing then throws exception', () async {
       expect(
         () => [projectIdOpt].prepareForParsing(parser),
-        throwsA(isA<OptionDefinitionError>().having(
-          (final e) => e.message,
-          'message',
-          "Mandatory options can't have default values",
+        throwsA(allOf(
+          isA<OptionDefinitionError>(),
+          (final e) => e
+              .toString()
+              .contains("Mandatory options can't have default values"),
         )),
       );
     });
@@ -1622,7 +1625,7 @@ void main() async {
   });
 }
 
-enum _TestOption<V extends Object> implements OptionDefinition<V> {
+enum _TestOption<V> implements OptionDefinition<V> {
   stringOpt(
     StringOption(
       argName: 'string',


### PR DESCRIPTION
This reverts two previous commits, for the cli_tools and config packages respectively, that forced explicit generic type specification in all usages of the packages' classes. This made for a worse developer experience without adding any value.

By reverting these commits we will be using Dart's default rules.

(Note: Since serverpod_lints currently enables stricter rules than Dart's default, they are explicitly disable here. When serverpod_lints removes these as is planned, this can be removed here as well.)