### PR TITLE
chore(release): Publish packages 0.8.0-beta.1

### DIFF
--- a/packages/cli_tools/CHANGELOG.md
+++ b/packages/cli_tools/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.0-beta.1
+
+ - **REVERT**: Do not force strict generic types (#64).
+ - **FEAT**: Experimental command line completion support (#65).
+
 ## 0.8.0-beta.0
 
  - **BREAKING** **FIX**: Resolved raw generic type warnings (#62).

--- a/packages/cli_tools/pubspec.yaml
+++ b/packages/cli_tools/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.8.0-beta.0
+version: 0.8.0-beta.1
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev
@@ -17,7 +17,7 @@ environment:
 dependencies:
   args: ^2.7.0
   ci: ^0.1.0
-  config: ^0.8.0-beta.0
+  config: ^0.8.0-beta.1
   http: '>=0.13.0 <2.0.0'
   path: ^1.8.2
   pub_api_client: '>=2.4.0 <4.0.0'

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0-beta.1
+
+ - **REVERT**: Do not force strict generic types (#64).
+
 ## 0.8.0-beta.0
 
  - **BREAKING** **FIX**: Resolved raw generic type warnings (#62).

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: config
-version: 0.8.0-beta.0
+version: 0.8.0-beta.1
 description: A package for parsing command-line arguments and configuration files.
 repository: https://github.com/serverpod/cli_tools
 issue_tracker: https://github.com/serverpod/cli_tools/issues


### PR DESCRIPTION
 - cli_tools@0.8.0-beta.1
 - config@0.8.0-beta.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added 0.8.0-beta.1 release notes highlighting: experimental command-line completion support and a revert of strict generic type enforcement. Existing changelog entries remain unchanged. No functional behavior changes included in this PR.
- Chores
  - Bumped package versions to 0.8.0-beta.1 and aligned dependency constraints to the new version across related packages to prepare the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->