### PR TITLE
chore(release): Publish packages v0.8.0

### DIFF
--- a/packages/cli_tools/CHANGELOG.md
+++ b/packages/cli_tools/CHANGELOG.md
@@ -1,11 +1,7 @@
-## 0.8.0-beta.1
+## 0.8.0
 
- - **REVERT**: Do not force strict generic types (#64).
- - **FEAT**: Experimental command line completion support (#65).
-
-## 0.8.0-beta.0
-
- - **BREAKING** **FIX**: Resolved raw generic type warnings (#62).
+ - **FEAT**: Command line completion support (#65).
+ - **FIX**: Ensure tested up to Dart 3.9 (#62).
 
 ## 0.7.1
 

--- a/packages/cli_tools/pubspec.yaml
+++ b/packages/cli_tools/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.8.0-beta.1
+version: 0.8.0
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev
@@ -17,7 +17,7 @@ environment:
 dependencies:
   args: ^2.7.0
   ci: ^0.1.0
-  config: ^0.8.0-beta.1
+  config: ^0.8.0
   http: '>=0.13.0 <2.0.0'
   path: ^1.8.2
   pub_api_client: '>=2.4.0 <4.0.0'

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 0.8.0-beta.1
+## 0.8.0
 
- - **REVERT**: Do not force strict generic types (#64).
-
-## 0.8.0-beta.0
-
- - **BREAKING** **FIX**: Resolved raw generic type warnings (#62).
+ - **FEAT**: multiParser getter in MultiOption (#67).
+ - **FIX**: Ensure tested up to Dart 3.9 (#62).
 
 ## 0.7.2
 

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: config
-version: 0.8.0-beta.1
+version: 0.8.0
 description: A package for parsing command-line arguments and configuration files.
 repository: https://github.com/serverpod/cli_tools
 issue_tracker: https://github.com/serverpod/cli_tools/issues


### PR DESCRIPTION
 - cli_tools@0.8.0
 - config@0.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Consolidated 0.8.0 release notes by merging beta entries into a single stable section.
  - Clarified included items (e.g., command-line completion, Dart 3.9 testing) and removed obsolete experimental/revert notes.
- Chores
  - Promoted packages from 0.8.0-beta.1 to 0.8.0.
  - Aligned dependency versions to stable 0.8.0.
  - No runtime or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->