### PR TITLE
refactor(cli_tools): Deprecated CommandDocumentationGenerator

### DIFF
--- a/packages/cli_tools/lib/src/documentation_generator/documentation_generator.dart
+++ b/packages/cli_tools/lib/src/documentation_generator/documentation_generator.dart
@@ -1,5 +1,7 @@
 import '../../better_command_runner.dart' show BetterCommandRunner;
 
+@Deprecated(
+    'This is highly use case specific and will be removed from this package in the future.')
 class CommandDocumentationGenerator {
   final BetterCommandRunner commandRunner;
 

--- a/packages/cli_tools/test/documentation_generator/generate_markdown_test.dart
+++ b/packages/cli_tools/test/documentation_generator/generate_markdown_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:async';
 
 import 'package:args/command_runner.dart';


### PR DESCRIPTION
CommandDocumentationGenerator is highly use case specific, no longer used by cloud, and will be removed from this package in the future as it does not fit with general purpose components and is not a priority to develop into one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked the command documentation generator as deprecated; it will be removed in a future release. Plan migration if you rely on this component.

* **Tests**
  * Suppressed a deprecation-related lint in the test suite to avoid noise from the newly deprecated component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->