### PR TITLE
feat(cli_tools): Enable IP geotracking in analytics events

### DIFF
--- a/packages/cli_tools/lib/src/analytics/analytics.dart
+++ b/packages/cli_tools/lib/src/analytics/analytics.dart
@@ -22,7 +22,7 @@ class MixPanelAnalytics implements Analytics {
   final String _projectToken;
   final String _version;
 
-  final String _endpoint;
+  final Uri _endpoint;
   final Duration _timeout;
 
   MixPanelAnalytics({
@@ -35,9 +35,27 @@ class MixPanelAnalytics implements Analytics {
   })  : _uniqueUserId = uniqueUserId,
         _projectToken = projectToken,
         _version = version,
-        _endpoint = (endpoint ?? _defaultEndpoint) +
-            (disableIpTracking ? '?ip=0' : '?ip=1'),
+        _endpoint = _buildEndpoint(
+          endpoint ?? _defaultEndpoint,
+          disableIpTracking,
+        ),
         _timeout = timeout;
+
+  static Uri _buildEndpoint(
+    final String baseEndpoint,
+    final bool disableIpTracking,
+  ) {
+    final uri = Uri.parse(baseEndpoint);
+    final ipValue = disableIpTracking ? '0' : '1';
+
+    final updatedUri = uri.replace(
+      queryParameters: {
+        ...uri.queryParameters,
+        'ip': ipValue,
+      },
+    );
+    return updatedUri;
+  }
 
   @override
   void cleanUp() {}
@@ -74,7 +92,7 @@ class MixPanelAnalytics implements Analytics {
   Future<void> _quietPost(final String payload) async {
     try {
       await http.post(
-        Uri.parse(_endpoint),
+        _endpoint,
         body: 'data=$payload',
         headers: {
           'Accept': 'text/plain',


### PR DESCRIPTION
To enable IP-based geotracking of the client origin, MixPanel requires the URI query parameter `ip` to be set to 1. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to disable IP tracking in analytics for enhanced privacy control.

* **Improvements**
  * Analytics endpoint handling updated to correctly preserve existing query parameters when toggling IP tracking, improving reliability of analytics requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->