### PR TITLE
chore(release): Bump version

### DIFF
--- a/packages/cli_tools/CHANGELOG.md
+++ b/packages/cli_tools/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+ - **FEAT**(cli_tools): Add execute helper function to run shell commands (#90).
+
 ## 0.9.1
 
  - **FEAT**(cli_tools): Make the analytics behavior customizable (#87).

--- a/packages/cli_tools/pubspec.yaml
+++ b/packages/cli_tools/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.9.1
+version: 0.10.0
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev


### PR DESCRIPTION
# Changes

Bump cli tools versions


I manually did this, melos doesn't seem to work, it says it cannot find the package. Not sure what is going on there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper function to execute shell commands
  
* **Chores**
  * Version bump to 0.10.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->