### PR TITLE
fix(logger): Preserve box alignment for ANSI-styled warnings/errors

### DIFF
--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -245,7 +245,13 @@ String _styleByLevel(final String message, final LogLevel level) {
 }
 
 String _stripAnsiCodes(final String input) {
-  final ansiRegex = RegExp(r'\x1B\[[0-9;]*m');
+  // Matches ANSI/VT escape sequences including:
+  // - C1 control chars introduced by ESC
+  // - CSI sequences (ESC [ ... final-byte)
+  // - OSC sequences (ESC ] ... BEL or ESC \\)
+  final ansiRegex = RegExp(
+    r'\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])',
+  );
   return input.replaceAll(ansiRegex, '');
 }
 

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -159,9 +159,12 @@ class StdOutLogger extends Logger {
     if (type is BoxLogType) {
       message = _formatAsBox(
         wrapColumn: wrapTextColumn ?? _defaultColumnWrap,
-        message: message,
+        message: _stripAnsiCodes(message),
         title: type.title,
       );
+      if (ansiSupported) {
+        message = _styleByLevel(message, logLevel);
+      }
     } else if (type is TextLogType) {
       switch (type.style) {
         case TextLogStyle.command:
@@ -235,6 +238,21 @@ class StdOutLogger extends Logger {
 
     trackedAnimationInProgress = null;
   }
+}
+
+String _styleByLevel(final String message, final LogLevel level) {
+  return switch (level) {
+    LogLevel.debug => AnsiStyle.darkGray.wrap(message),
+    LogLevel.info => message,
+    LogLevel.warning => AnsiStyle.yellow.wrap(message),
+    LogLevel.error => AnsiStyle.red.wrap(message),
+    LogLevel.nothing => message,
+  };
+}
+
+String _stripAnsiCodes(final String input) {
+  final ansiRegex = RegExp(r'\x1B\[[0-9;]*m');
+  return input.replaceAll(ansiRegex, '');
 }
 
 /// wrap text based on column width

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -94,13 +94,7 @@ class StdOutLogger extends Logger {
     final LogType type = TextLogType.normal,
   }) {
     if (ansiSupported) {
-      final ansiMessage = switch (level) {
-        LogLevel.debug => AnsiStyle.darkGray.wrap(message),
-        LogLevel.info => message,
-        LogLevel.warning => AnsiStyle.yellow.wrap(message),
-        LogLevel.error => AnsiStyle.red.wrap(message),
-        LogLevel.nothing => message,
-      };
+      final ansiMessage = _styleByLevel(message, level);
 
       _log(ansiMessage, level, newParagraph, type);
     } else {

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -154,7 +154,7 @@ class StdOutLogger extends Logger {
       message = _formatAsBox(
         wrapColumn: wrapTextColumn ?? _defaultColumnWrap,
         message: _stripAnsiCodes(message),
-        title: type.title,
+        title: type.title != null ? _stripAnsiCodes(type.title!) : null,
       );
       if (ansiSupported) {
         message = _styleByLevel(message, logLevel);

--- a/packages/cli_tools/test/std_out_logger_test.dart
+++ b/packages/cli_tools/test/std_out_logger_test.dart
@@ -176,6 +176,27 @@ void main() {
       );
       expect(stderr.output, '');
     });
+
+    test(
+        'when logging boxed text containing non-SGR ANSI sequences '
+        'then control sequences are stripped before width calculation',
+        () async {
+      final (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.warning(
+          '\x1B]8;;https://example.com\x07click\x1B]8;;\x07',
+          type: BoxLogType(title: '\x1B[2Kwarn\x1B[0G'),
+        ),
+      );
+
+      expect(stdout.output.contains('\x1B'), isFalse);
+      expect(
+        stdout.output,
+        '┌─ warn ─┐\n'
+        '│ click │\n'
+        '└───────┘\n',
+      );
+      expect(stderr.output, '');
+    });
   });
 }
 

--- a/packages/cli_tools/test/std_out_logger_test.dart
+++ b/packages/cli_tools/test/std_out_logger_test.dart
@@ -137,4 +137,45 @@ void main() {
       expect(stderr.output, 'ERROR: error message\n');
     });
   });
+
+  group('Given a StdOutLogger logging BoxLogType messages', () {
+    final logger = StdOutLogger(LogLevel.debug);
+
+    test(
+        'when logging boxed plain text '
+        'then it renders the expected box framing', () async {
+      final (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.info('hello world', type: BoxLogType(title: 'title')),
+      );
+
+      expect(
+        stdout.output,
+        '┌─ title ─────┐\n'
+        '│ hello world │\n'
+        '└─────────────┘\n',
+      );
+      expect(stderr.output, '');
+    });
+
+    test(
+        'when logging boxed ANSI-styled text '
+        'then ANSI codes are stripped before width calculation', () async {
+      final (:stdout, :stderr, :stdin) = await collectOutput(
+        () => logger.warning(
+          '\x1B[33mwarning\x1B[0m',
+          type: BoxLogType(title: '\x1B[31mwarn\x1B[0m'),
+        ),
+      );
+
+      expect(stdout.output.contains('\x1B['), isFalse);
+      expect(
+        stdout.output,
+        '┌─ warn ──┐\n'
+        '│ warning │\n'
+        '└─────────┘\n',
+      );
+      expect(stderr.output, '');
+    });
+  });
 }
+

--- a/packages/cli_tools/test/std_out_logger_test.dart
+++ b/packages/cli_tools/test/std_out_logger_test.dart
@@ -165,11 +165,17 @@ void main() {
           '\x1B[33mwarning\x1B[0m',
           type: BoxLogType(title: '\x1B[31mwarn\x1B[0m'),
         ),
+        ansiSupported: true,
       );
 
-      expect(stdout.output.contains('\x1B['), isFalse);
+      final stripped = stdout.output.replaceAll(
+        RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\\\)|\x1B[@-Z\\\\-_]'),
+        '',
+      );
+
+      expect(stdout.output.contains('\x1B['), isTrue);
       expect(
-        stdout.output,
+        stripped,
         '┌─ warn ──┐\n'
         '│ warning │\n'
         '└─────────┘\n',
@@ -186,11 +192,17 @@ void main() {
           '\x1B]8;;https://example.com\x07click\x1B]8;;\x07',
           type: BoxLogType(title: '\x1B[2Kwarn\x1B[0G'),
         ),
+        ansiSupported: true,
       );
 
-      expect(stdout.output.contains('\x1B'), isFalse);
+      final stripped = stdout.output.replaceAll(
+        RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\\\)|\x1B[@-Z\\\\-_]'),
+        '',
+      );
+
+      expect(stdout.output.contains('\x1B'), isTrue);
       expect(
-        stdout.output,
+        stripped,
         '┌─ warn ─┐\n'
         '│ click │\n'
         '└───────┘\n',

--- a/packages/cli_tools/test/std_out_logger_test.dart
+++ b/packages/cli_tools/test/std_out_logger_test.dart
@@ -6,6 +6,13 @@ import 'package:test/test.dart';
 
 import 'test_utils/io_helper.dart';
 
+
+final _ansiRegex = RegExp(
+  r'\x1B\[[0-?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\\\)|\x1B[@-Z\\\\-_]',
+);
+
+String _stripAnsi(final String input) => input.replaceAll(_ansiRegex, '');
+
 void main() {
   group('Given a StdOutLogger with default settings', () {
     final logger = StdOutLogger(LogLevel.debug);
@@ -168,10 +175,7 @@ void main() {
         ansiSupported: true,
       );
 
-      final stripped = stdout.output.replaceAll(
-        RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\\\)|\x1B[@-Z\\\\-_]'),
-        '',
-      );
+      final stripped = _stripAnsi(stdout.output);
 
       expect(stdout.output.contains('\x1B['), isTrue);
       expect(
@@ -195,10 +199,7 @@ void main() {
         ansiSupported: true,
       );
 
-      final stripped = stdout.output.replaceAll(
-        RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]|\x1B\][^\x07\x1B]*(?:\x07|\x1B\\\\)|\x1B[@-Z\\\\-_]'),
-        '',
-      );
+      final stripped = _stripAnsi(stdout.output);
 
       expect(stdout.output.contains('\x1B'), isTrue);
       expect(

--- a/packages/cli_tools/test/test_utils/io_helper.dart
+++ b/packages/cli_tools/test/test_utils/io_helper.dart
@@ -12,7 +12,7 @@ Future<({MockStdout stdout, MockStdout stderr, MockStdin stdin})>
   final bool ansiSupported = false,
 }) async {
   final standardOut = MockStdout(ansiSupported: ansiSupported);
-  final standardError = MockStdout();
+  final standardError = MockStdout(ansiSupported: ansiSupported);
   final standardIn = MockStdin(textInputs: stdinLines, keyInputs: keyInputs);
 
   await IOOverrides.runZoned(

--- a/packages/cli_tools/test/test_utils/io_helper.dart
+++ b/packages/cli_tools/test/test_utils/io_helper.dart
@@ -9,8 +9,9 @@ Future<({MockStdout stdout, MockStdout stderr, MockStdin stdin})>
   final FutureOr<T> Function() runner, {
   final List<String> stdinLines = const [],
   final List<int> keyInputs = const [],
+  final bool ansiSupported = false,
 }) async {
-  final standardOut = MockStdout();
+  final standardOut = MockStdout(ansiSupported: ansiSupported);
   final standardError = MockStdout();
   final standardIn = MockStdin(textInputs: stdinLines, keyInputs: keyInputs);
 

--- a/packages/cli_tools/test/test_utils/mock_stdout.dart
+++ b/packages/cli_tools/test/test_utils/mock_stdout.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 
 class MockStdout implements Stdout {
+  MockStdout({this.ansiSupported = false});
+
+  final bool ansiSupported;
   final _buffer = StringBuffer();
 
   @override
@@ -49,7 +52,7 @@ class MockStdout implements Stdout {
   IOSink get nonBlocking => throw UnimplementedError();
 
   @override
-  bool get supportsAnsiEscapes => false;
+  bool get supportsAnsiEscapes => ansiSupported;
 
   @override
   int get terminalColumns => 80;


### PR DESCRIPTION
## Summary
- fix box rendering for warning/error logs when ANSI coloring is enabled
- strip ANSI escape codes before computing wrapped line widths and padding inside `_formatAsBox`
- re-apply level styling to the fully formatted box so visible borders and content keep consistent widths

## Testing
- Not run locally: `dart` is not available in this execution environment (`dart: command not found`), so I could not execute `dart test`.
- Manual verification approach used for the fix: inspected the formatting path to ensure width calculations now use plain text and no longer include ANSI control sequences.

## Related
Fixes #104


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Boxed log messages now strip existing ANSI escape sequences before boxing and reapply level-based styling afterward, preventing visual corruption and ensuring correct box sizing and colors.
* **Tests**
  * Added tests verifying boxed message rendering, confirming ANSI-styled text and other control sequences are stripped for sizing and rendered correctly in a box.
* **Chores**
  * Test harness updated to simulate ANSI-capable output for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->