### PR TITLE
feat(cli_tools): Added Logger.progressStream method 

### DIFF
--- a/.cursor/rules/dart-test-conventions.mdc
+++ b/.cursor/rules/dart-test-conventions.mdc
@@ -52,7 +52,7 @@ group('when running with no command', () {
 
   test('then error message is logged to errors.', () async {
     expect(errors, hasLength(1));
-    expect(errors[0], contains('erronous usage'));
+    expect(errors[0], contains('erroneous usage'));
   });
 
   test('then no warning message is logged', () async {

--- a/.cursor/rules/dart-test-conventions.mdc
+++ b/.cursor/rules/dart-test-conventions.mdc
@@ -1,0 +1,93 @@
+---
+description: Given-when-then naming and structure for Dart tests in this repo
+globs: packages/**/test/**/*_test.dart
+alwaysApply: false
+---
+
+# Dart test conventions (Given – when – then)
+
+Use the **Given – when – then** pattern for test names and structure.
+This matches existing tests such as `std_out_logger_test.dart`, `progress_test.dart`, and `configuration_test.dart`.
+
+## Structure
+
+| Part | Role | Where it lives |
+|------|------|----------------|
+| **Given** | Preconditions and shared setup | Top-level `group('Given …')` |
+| **when** | The action or trigger | Nested `group('when …')` and/or start of `test` name |
+| **then** | Expected outcome | End of `test` name; verified with `expect` in the body |
+
+Prefer **nested groups** when several tests share the same Given or when:
+
+```dart
+group('Given a StdOutLogger with info log level', () {
+  final logger = StdOutLogger(LogLevel.info);
+
+  group('when calling progressStream', () {
+    test(
+        'when stream has a single event '
+        'then the event is returned and progress is marked successful',
+        () async {
+      // arrange/act in body, assert with expect
+    });
+  });
+});
+```
+
+When a parent `group` already states **when**, child tests may use only **then**.
+
+Prefer to have multiple **then** tests for multiple outcome verifications,
+there should be one test method per expected outcome condition.
+This means that for each **then** test, there should only be one or very few
+expect calls, which are directly related to the same outcome verification:
+
+```dart
+group('when running with no command', () {
+  setUp(() async => await runner.run([]));
+
+  test('then usage message is logged to info.', () async {
+    expect(infos, hasLength(1));
+    expect(infos[0], contains('usage'));
+  });
+
+  test('then error message is logged to errors.', () async {
+    expect(errors, hasLength(1));
+    expect(errors[0], contains('erronous usage'));
+  });
+
+  test('then no warning message is logged', () async {
+    expect(errors, isEmpty);
+  });
+});
+```
+
+For isolated cases without shared setup, put the full pattern in one test name:
+
+```dart
+test(
+    'Given confirm prompt'
+    ' when providing valid input "yes"'
+    ' then should return true', () async {
+  // ...
+});
+```
+
+## Naming rules
+
+- Start Given groups with `Given …` (e.g. `Given a StdOutLogger with default settings`).
+- Use lowercase **when** and **then** in names.
+- Describe behaviour, not implementation (e.g. `then progress is marked failed`, not `then fail() is called`).
+- Split long names across adjacent string literals; do not use one unreadable line.
+
+## Test body
+
+- Put shared fixtures, loggers, and runners in the **Given** group scope.
+- Run the action under test inside the test body (or in a **when** group's `setUp`).
+- Use `expect` / `expectLater` for **then** assertions only—do not restate expectations in the name alone.
+- For stdout/stderr tests, use `collectOutput` from `test_utils/io_helper.dart`.
+
+## Examples to follow
+
+- `packages/cli_tools/test/std_out_logger_test.dart` — Given group + `when … then …` tests
+- `packages/cli_tools/test/logger/progress_test.dart` — nested Given / when groups
+- `packages/config/test/config/configuration_test.dart` — nested Given / when / then groups

--- a/packages/cli_tools/lib/src/logger/logger.dart
+++ b/packages/cli_tools/lib/src/logger/logger.dart
@@ -48,8 +48,8 @@ abstract class Logger {
     final LogType type,
   });
 
-  /// Display a progress message on [LogLevel.info] while running [runner]
-  /// function.
+  /// Display a progress spinner and message on [LogLevel.info] while running
+  /// [runner] function.
   ///
   /// Uses return value from [runner] to print set progress success status.
   /// Returns return value from [runner].
@@ -57,6 +57,26 @@ abstract class Logger {
     final String message,
     final Future<bool> Function() runner, {
     final bool newParagraph,
+  });
+
+  /// Display a progress spinner and a stream of messages on [LogLevel.info].
+  /// When the stream is ended, the progress spinner is completed, with a
+  /// failure status if the stream ends with an error.
+  ///
+  /// First [initialMessage] is displayed, then the message is updated with each
+  /// event. A custom [toMessage] can be provided to convert each event to an
+  /// appropriate message. If not provided, [toString] is called on the event.
+  ///
+  /// For streams with a single event this method behaves like [progress].
+  ///
+  /// Returns the last event from the stream.
+  /// If the stream ends with an error, that error is rethrown.
+  /// If the stream is empty, [StateError] is thrown.
+  Future<T> progressStream<T>(
+    final String initialMessage,
+    final Stream<T> stream, {
+    final String Function(T)? toMessage,
+    final bool newParagraph = false,
   });
 
   /// Directly write a [message] to the output.

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -145,13 +145,15 @@ class StdOutLogger extends Logger {
     final progress = Progress(initialMessage, stdout);
     trackedAnimationInProgress = progress;
     try {
+      bool hasEvent = false;
       T? finalEvent;
       await for (final event in stream) {
+        hasEvent = true;
         finalEvent = event;
         final message = toMessage?.call(event) ?? event.toString();
         progress.update(message);
       }
-      if (finalEvent is! T) {
+      if (!hasEvent || finalEvent is! T) {
         throw StateError('No events in stream');
       }
       progress.complete();

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -130,9 +130,13 @@ class StdOutLogger extends Logger {
 
     final progress = Progress(message, stdout);
     trackedAnimationInProgress = progress;
-    final bool success = await runner();
-    trackedAnimationInProgress = null;
-    success ? progress.complete() : progress.fail();
+    bool success = false;
+    try {
+      success = await runner();
+    } finally {
+      trackedAnimationInProgress = null;
+      success ? progress.complete() : progress.fail();
+    }
     return success;
   }
 

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -116,28 +116,52 @@ class StdOutLogger extends Logger {
     final Future<bool> Function() runner, {
     final bool newParagraph = false,
   }) async {
+    return await progressStream(
+      message,
+      Stream.fromFuture(runner()),
+      toMessage: (final _) => message,
+      newParagraph: newParagraph,
+    );
+  }
+
+  @override
+  Future<T> progressStream<T>(
+    final String initialMessage,
+    final Stream<T> stream, {
+    final String Function(T)? toMessage,
+    final bool newParagraph = false,
+  }) async {
     if (logLevel.index > LogLevel.info.index) {
-      return await runner();
+      return stream.last;
     }
 
     _stopAnimationInProgress();
 
-    // Write an empty line before the progress message if a new paragraph is
-    // requested.
+    // First write an empty line if a new paragraph is requested.
     if (newParagraph) {
       write('', LogLevel.info, newParagraph: false, newLine: true);
     }
 
-    final progress = Progress(message, stdout);
+    final progress = Progress(initialMessage, stdout);
     trackedAnimationInProgress = progress;
-    bool success = false;
     try {
-      success = await runner();
+      T? finalEvent;
+      await for (final event in stream) {
+        finalEvent = event;
+        final message = toMessage?.call(event) ?? event.toString();
+        progress.update(message);
+      }
+      if (finalEvent is! T) {
+        throw StateError('No events in stream');
+      }
+      progress.complete();
+      return finalEvent;
+    } catch (error) {
+      progress.fail();
+      rethrow;
     } finally {
       trackedAnimationInProgress = null;
-      success ? progress.complete() : progress.fail();
     }
-    return success;
   }
 
   @override

--- a/packages/cli_tools/lib/src/logger/loggers/void_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/void_logger.dart
@@ -61,6 +61,16 @@ class VoidLogger extends Logger {
   }
 
   @override
+  Future<T> progressStream<T>(
+    final String initialMessage,
+    final Stream<T> stream, {
+    final String Function(T)? toMessage,
+    final bool newParagraph = false,
+  }) {
+    return stream.last;
+  }
+
+  @override
   void write(
     final String message,
     final LogLevel logLevel, {

--- a/packages/cli_tools/test/logger/progress_test.dart
+++ b/packages/cli_tools/test/logger/progress_test.dart
@@ -1,3 +1,6 @@
+// ignore required for Dart 3.3
+// ignore_for_file: unused_local_variable
+
 import 'package:cli_tools/cli_tools.dart';
 import 'package:test/test.dart';
 

--- a/packages/cli_tools/test/logger/progress_test.dart
+++ b/packages/cli_tools/test/logger/progress_test.dart
@@ -1,0 +1,193 @@
+import 'package:cli_tools/cli_tools.dart';
+import 'package:test/test.dart';
+
+import '../test_utils/io_helper.dart';
+
+void main() {
+  group('Given a StdOutLogger with info log level', () {
+    final logger = StdOutLogger(LogLevel.info);
+
+    group('when calling progress', () {
+      test(
+          'when runner completes successfully '
+          'then runner result is returned and progress is marked successful',
+          () async {
+        bool? result;
+
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          result = await logger.progress('Working', () async => true);
+        });
+
+        expect(result, isTrue);
+        expect(stdout.output, contains('Working'));
+        expect(stdout.output, contains('✓'));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when runner throws an exception '
+          'then progress is marked failed and the exception is rethrown',
+          () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await expectLater(
+            logger.progress('Working', () async => throw Exception('failed')),
+            throwsA(isA<Exception>()),
+          );
+        });
+
+        expect(stdout.output, contains('Working'));
+        expect(stdout.output, contains('✗'));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+    });
+
+    group('when calling progressStream', () {
+      test(
+          'when stream has no events '
+          'then StateError is thrown and progress is marked failed', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await expectLater(
+            logger.progressStream<int>('Starting', const Stream<int>.empty()),
+            throwsA(
+              isA<StateError>().having(
+                (final e) => e.message,
+                'message',
+                'No events in stream',
+              ),
+            ),
+          );
+        });
+
+        expect(stdout.output, contains('Starting'));
+        expect(stdout.output, contains('✗'));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when stream has a single event '
+          'then the event is returned and progress is marked successful',
+          () async {
+        int? result;
+
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          result = await logger.progressStream('Starting', Stream.value(42));
+        });
+
+        expect(result, 42);
+        expect(stdout.output, contains('Starting'));
+        expect(stdout.output, contains('42'));
+        expect(stdout.output, contains('✓'));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when stream has several events '
+          'then each event updates the message and the last event is returned',
+          () async {
+        int? result;
+
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          result = await logger.progressStream(
+            'Starting',
+            Stream.fromIterable([1, 2, 3]),
+            toMessage: (final step) => 'Step $step',
+          );
+        });
+
+        expect(result, 3);
+        expect(stdout.output, contains('Starting'));
+        expect(stdout.output, contains('Step 1'));
+        expect(stdout.output, contains('Step 2'));
+        expect(stdout.output, contains('Step 3'));
+        expect(stdout.output, contains('✓'));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when stream completes successfully '
+          'then progress is marked successful', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await logger.progressStream(
+            'Deploying',
+            Stream.fromIterable(['build', 'deploy']),
+            toMessage: (final phase) => phase,
+          );
+        });
+
+        expect(stdout.output, contains('Deploying'));
+        expect(stdout.output, contains('deploy'));
+        expect(stdout.output, contains('✓'));
+        expect(stdout.output, isNot(contains('✗')));
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when stream throws an exception '
+          'then progress is marked failed and the exception is rethrown',
+          () async {
+        Stream<int> failingStream() async* {
+          yield 1;
+          throw Exception('stream failed');
+        }
+
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await expectLater(
+            logger.progressStream('Starting', failingStream()),
+            throwsA(isA<Exception>()),
+          );
+        });
+
+        expect(stdout.output, contains('Starting'));
+        expect(stdout.output, contains('1'));
+        expect(stdout.output, contains('✗'));
+        expect(stdout.output, isNot(contains('✓')));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when newParagraph is true '
+          'then a leading newline is written before progress output', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await logger.progressStream(
+            'Starting',
+            Stream.value('done'),
+            newParagraph: true,
+          );
+        });
+
+        expect(stdout.output, startsWith('\n'));
+        expect(stdout.output, contains('✓'));
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+    });
+  });
+
+  group('Given a StdOutLogger with warning log level', () {
+    final logger = StdOutLogger(LogLevel.warning);
+
+    test(
+        'when calling progressStream '
+        'then no progress output is written and the last event is returned',
+        () async {
+      int? result;
+
+      final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+        result = await logger.progressStream(
+          'Hidden',
+          Stream.fromIterable([1, 2, 3]),
+        );
+      });
+
+      expect(result, 3);
+      expect(stdout.output, isEmpty);
+      expect(stderr.output, isEmpty);
+      expect(logger.trackedAnimationInProgress, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Supports displaying multiple updated status strings during the run of a progress spinner.

Also makes progress and progressStream to handle exceptions by ending the animation with a failure message and rethrowing.

Also adds cursor rule file for writing tests according to our given - when - then convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamed progress display with per-event message formatting and returns the last event value.
  * Added Dart test naming/convention rule for Given–when–then style.

* **Bug Fixes**
  * More reliable progress handling: proper cleanup, failure signaling, and error propagation for streamed progress.

* **Documentation**
  * Clarified progress spinner behavior and options.

* **Tests**
  * New tests covering progress and streamed-progress behaviors, success/failure cases, paragraph option, and output suppression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverpod/cli_tools/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->