### PR TITLE
chore(release): Publish cli_tools 0.13.0

### DIFF
--- a/packages/cli_tools/CHANGELOG.md
+++ b/packages/cli_tools/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.0
+
+ - **BREAKING** **FEAT**(cli_tools): Adds a `flush` method to the `Analytics` base class to ensure all analytics events are sent before the program exits ([#107](https://github.com/serverpod/cli_tools/issues/107)). ([87b037e2](https://github.com/serverpod/cli_tools/commit/87b037e2b8172252e399cb103d103054ede64267))
+
 ## 0.12.0
 
  - Bumped minimum Dart SDK version to 3.6

--- a/packages/cli_tools/CHANGELOG.md
+++ b/packages/cli_tools/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.13.0
 
  - **BREAKING** **FEAT**(cli_tools): Adds a `flush` method to the `Analytics` base class to ensure all analytics events are sent before the program exits ([#107](https://github.com/serverpod/cli_tools/issues/107)). ([87b037e2](https://github.com/serverpod/cli_tools/commit/87b037e2b8172252e399cb103d103054ede64267))
+ - FIX(cli_tools): Make VoidLogger.progressStream throw same exception as StdOutLogger does on empty stream. ([861fe7f0](https://github.com/serverpod/cli_tools/commit/861fe7f025e973fb510d24f9750c8246eb25926e))
+ - FIX(cli_tools): Fixed regression in progress spinner on unsuccessful runner. ([861fe7f0](https://github.com/serverpod/cli_tools/commit/861fe7f025e973fb510d24f9750c8246eb25926e))
 
 ## 0.12.0
 

--- a/packages/cli_tools/pubspec.yaml
+++ b/packages/cli_tools/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cli_tools
-version: 0.12.0
+version: 0.13.0
 description: A collection of tools for building great command-line interfaces.
 repository: https://github.com/serverpod/cli_tools
 homepage: https://serverpod.dev


### PR DESCRIPTION
Publish next cli_tools with the improvements on the `Analytics` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ensures analytics events are reliably sent before the CLI exits.

* **Breaking Changes**
  * Analytics behavior updated; callers may need to adapt to the new lifecycle.

* **Bug Fixes**
  * Fixed an exception condition in progress reporting.
  * Restored progress spinner behavior for failed runner executions.

* **Documentation**
  * Updated changelog for the 0.13.0 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->