### PR TITLE
fix(cli_tools): Matching behavior in VoidLogger; fixed regression

### DIFF
--- a/packages/cli_tools/lib/src/logger/logger.dart
+++ b/packages/cli_tools/lib/src/logger/logger.dart
@@ -51,7 +51,7 @@ abstract class Logger {
   /// Display a progress spinner and message on [LogLevel.info] while running
   /// [runner] function.
   ///
-  /// Uses return value from [runner] to print set progress success status.
+  /// Uses the return value from [runner] to print success or failure status.
   /// Returns return value from [runner].
   Future<bool> progress(
     final String message,
@@ -67,6 +67,10 @@ abstract class Logger {
   /// event. A custom [toMessage] can be provided to convert each event to an
   /// appropriate message. If not provided, [toString] is called on the event.
   ///
+  /// If [isSuccess] is provided, it is used to determine if the progress should
+  /// be marked as successful or failed. If not provided, the progress is marked
+  /// as successful if the stream ends without an error.
+  ///
   /// For streams with a single event this method behaves like [progress].
   ///
   /// Returns the last event from the stream.
@@ -76,6 +80,7 @@ abstract class Logger {
     final String initialMessage,
     final Stream<T> stream, {
     final String Function(T)? toMessage,
+    final bool Function(T)? isSuccess,
     final bool newParagraph = false,
   });
 

--- a/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/std_out_logger.dart
@@ -120,6 +120,7 @@ class StdOutLogger extends Logger {
       message,
       Stream.fromFuture(runner()),
       toMessage: (final _) => message,
+      isSuccess: (final result) => result,
       newParagraph: newParagraph,
     );
   }
@@ -129,6 +130,7 @@ class StdOutLogger extends Logger {
     final String initialMessage,
     final Stream<T> stream, {
     final String Function(T)? toMessage,
+    final bool Function(T)? isSuccess,
     final bool newParagraph = false,
   }) async {
     if (logLevel.index > LogLevel.info.index) {
@@ -156,7 +158,8 @@ class StdOutLogger extends Logger {
       if (!hasEvent || finalEvent is! T) {
         throw StateError('No events in stream');
       }
-      progress.complete();
+      final success = isSuccess?.call(finalEvent) ?? true;
+      success ? progress.complete() : progress.fail();
       return finalEvent;
     } catch (error) {
       progress.fail();

--- a/packages/cli_tools/lib/src/logger/loggers/void_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/void_logger.dart
@@ -66,8 +66,12 @@ class VoidLogger extends Logger {
     final Stream<T> stream, {
     final String Function(T)? toMessage,
     final bool newParagraph = false,
-  }) {
-    return stream.last;
+  }) async {
+    try {
+      return await stream.last;
+    } on StateError catch (_) {
+      throw StateError('No events in stream');
+    }
   }
 
   @override

--- a/packages/cli_tools/lib/src/logger/loggers/void_logger.dart
+++ b/packages/cli_tools/lib/src/logger/loggers/void_logger.dart
@@ -65,6 +65,7 @@ class VoidLogger extends Logger {
     final String initialMessage,
     final Stream<T> stream, {
     final String Function(T)? toMessage,
+    final bool Function(T)? isSuccess,
     final bool newParagraph = false,
   }) async {
     try {

--- a/packages/cli_tools/test/logger/progress_test.dart
+++ b/packages/cli_tools/test/logger/progress_test.dart
@@ -26,6 +26,23 @@ void main() {
       });
 
       test(
+          'when runner completes unsuccessfully '
+          'then runner result is returned and progress is marked unsuccessful',
+          () async {
+        bool? result;
+
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          result = await logger.progress('Working', () async => false);
+        });
+
+        expect(result, isFalse);
+        expect(stdout.output, contains('Working'));
+        expect(stdout.output, contains('✗'));
+        expect(stderr.output, isEmpty);
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
           'when runner throws an exception '
           'then progress is marked failed and the exception is rethrown',
           () async {
@@ -123,6 +140,46 @@ void main() {
         expect(stdout.output, contains('deploy'));
         expect(stdout.output, contains('✓'));
         expect(stdout.output, isNot(contains('✗')));
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when stream completes and result is successful '
+          'then progress is marked successful', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await logger.progressStream(
+            'Deploying',
+            Stream.fromIterable(['build', 'deploy']),
+            toMessage: (final phase) => phase,
+            isSuccess: (final phase) => phase == 'deploy',
+          );
+        });
+
+        print(stdout.output);
+        expect(stdout.output, contains('Deploying'));
+        expect(stdout.output, contains('deploy'));
+        expect(stdout.output, contains('✓'));
+        expect(stdout.output, isNot(contains('✗')));
+        expect(logger.trackedAnimationInProgress, isNull);
+      });
+
+      test(
+          'when stream completes but result is not successful '
+          'then progress is marked unsuccessful', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await logger.progressStream(
+            'Deploying',
+            Stream.fromIterable(['build', 'deploy']),
+            toMessage: (final phase) => phase,
+            isSuccess: (final phase) => phase == 'some-other-phase',
+          );
+        });
+
+        print(stdout.output);
+        expect(stdout.output, contains('Deploying'));
+        expect(stdout.output, contains('deploy'));
+        expect(stdout.output, contains('✗'));
+        expect(stdout.output, isNot(contains('✓')));
         expect(logger.trackedAnimationInProgress, isNull);
       });
 


### PR DESCRIPTION
Make VoidLogger.progressStream throw same exception as StdOutLogger does on empty stream.

Fixed regression in progress spinner on unsuccessful runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Let callers provide a custom success predicate so progress can be marked success or failure based on the final result.

* **Bug Fixes**
  * Better error handling for empty progress streams with a clearer "No events in stream" error.

* **Tests**
  * Added/updated tests to verify success/failure markers and output for progress flows.

* **Documentation**
  * Clarified progress behavior and the optional success predicate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverpod/cli_tools/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->