### PR TITLE
feat: Adds serverpod logging package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
       matrix:
         dart: [3.6, 3.12]
         package: [cli_tools, config, serverpod_logging]
+        exclude:
+          - package: serverpod_logging
+        include:
+          - package: serverpod_logging
+            dart: 3.10.3
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -37,6 +42,8 @@ jobs:
         dart: [3.6, 3.12]
         package: [cli_tools, config, serverpod_logging]
         platform: [ubuntu-latest]
+        exclude:
+          - package: serverpod_logging
         include:
           - package: cli_tools
             platform: windows-latest
@@ -44,6 +51,9 @@ jobs:
           - package: cli_tools
             platform: macos-latest
             dart: 3.6
+          - package: serverpod_logging
+            dart: 3.10.3
+            platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         dart: [3.6, 3.12]
-        package: [cli_tools, config]
+        package: [cli_tools, config, serverpod_logging]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         dart: [3.6, 3.12]
-        package: [cli_tools, config]
+        package: [cli_tools, config, serverpod_logging]
         platform: [ubuntu-latest]
         include:
           - package: cli_tools

--- a/packages/serverpod_logging/.gitignore
+++ b/packages/serverpod_logging/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/serverpod_logging/CHANGELOG.md
+++ b/packages/serverpod_logging/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial version.

--- a/packages/serverpod_logging/README.md
+++ b/packages/serverpod_logging/README.md
@@ -2,4 +2,4 @@
 
 # Serverpod Logging
 
-This package contains tools for bridging loggin between Serverpod framework and tooling.
+This package contains tools for bridging logging between Serverpod framework and tooling.

--- a/packages/serverpod_logging/README.md
+++ b/packages/serverpod_logging/README.md
@@ -1,0 +1,5 @@
+![Serverpod banner](https://github.com/serverpod/serverpod/raw/main/misc/images/github-header.webp)
+
+# Serverpod Logging
+
+This package contains tools for bridging loggin between Serverpod framework and tooling.

--- a/packages/serverpod_logging/analysis_options.yaml
+++ b/packages/serverpod_logging/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/serverpod_logging/analysis_options.yaml
+++ b/packages/serverpod_logging/analysis_options.yaml
@@ -1,30 +1,14 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
+include: package:serverpod_lints/cli.yaml
 
-include: package:lints/recommended.yaml
+analyzer:
+  language:
+    strict-raw-types: false
+  errors:
+    inference_failure_on_instance_creation: ignore
+    inference_failure_on_function_invocation: ignore
+    inference_failure_on_untyped_parameter: ignore
+    prefer_final_parameters: ignore
 
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
-
-# For additional information about configuring this file, see
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules:
+    prefer_relative_imports: true

--- a/packages/serverpod_logging/lib/serverpod_logging.dart
+++ b/packages/serverpod_logging/lib/serverpod_logging.dart
@@ -1,0 +1,6 @@
+export 'src/global_log.dart';
+export 'src/log_types.dart';
+export 'src/log.dart';
+export 'src/spinner_log_writer.dart';
+export 'src/test_log_writer.dart';
+export 'src/text_log_writer.dart';

--- a/packages/serverpod_logging/lib/serverpod_logging.dart
+++ b/packages/serverpod_logging/lib/serverpod_logging.dart
@@ -1,6 +1,6 @@
 export 'src/global_log.dart';
-export 'src/log_types.dart';
 export 'src/log.dart';
+export 'src/log_types.dart';
 export 'src/spinner_log_writer.dart';
 export 'src/test_log_writer.dart';
 export 'src/text_log_writer.dart';

--- a/packages/serverpod_logging/lib/src/global_log.dart
+++ b/packages/serverpod_logging/lib/src/global_log.dart
@@ -1,0 +1,20 @@
+import 'log.dart';
+import 'log_types.dart';
+
+/// Global writer chain that backs [log]. Callers configure the chain by
+/// adding writers with [MultiLogWriter.add] and removing them with
+/// [MultiLogWriter.remove]; identity is stable for the process lifetime,
+/// so the chain is shared across any number of [Log] consumers and
+/// framework bootstraps.
+///
+/// ```dart
+/// logWriter.add(MyLogWriter());
+/// log.info('Server started');
+/// ```
+final MultiLogWriter logWriter = MultiLogWriter([]);
+
+/// Global [Log] that forwards to [logWriter]. Identity is stable: the
+/// instance is constructed at library init and never reassigned. Entry
+/// points configure logging by mutating [logWriter], not by replacing
+/// [log].
+final Log log = Log(logWriter, logLevel: LogLevel.info);

--- a/packages/serverpod_logging/lib/src/log.dart
+++ b/packages/serverpod_logging/lib/src/log.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+
+import 'log_types.dart';
+
+/// Symbol used to store the current [LogScope] in Zone values.
+const Symbol _logScopeKey = #_logScope;
+
+final _stopwatch = Stopwatch()..start();
+int _scopeCounter = 0;
+String _newScopeId(String label) =>
+    '${label.hashCode}_${_stopwatch.elapsedTicks}_${++_scopeCounter}';
+
+/// A factory function that creates a [LogEntry].
+typedef LogEntryFactory = FutureOr<LogEntry> Function();
+
+/// A logger that delegates to a [LogWriter] and resolves the current
+/// [LogScope] from the Zone.
+///
+/// Each call appends onto a rolling `_latest` Future, so writes
+/// serialize in invocation order. [flush] awaits that tail; [close]
+/// does the same and blocks further dispatches.
+///
+/// ```dart
+/// log.info('Server started');
+/// await log.progress('Migration', () async {
+///   log.info('Step 1');
+/// });
+/// ```
+class Log {
+  final LogWriter _writer;
+  Future<void> _latest = Future.value();
+  bool _closed = false;
+
+  /// The minimum severity that will be forwarded to the writer. Calls below
+  /// this level short-circuit without invoking the [LogEntryFactory]. May
+  /// be changed at runtime (e.g. when a verbose flag is parsed).
+  LogLevel logLevel;
+
+  /// Creates a [Log] that forwards to [_writer]. Messages below [logLevel]
+  /// are dropped before the [LogEntryFactory] runs.
+  Log(this._writer, {this.logLevel = LogLevel.info});
+
+  /// The current scope from the Zone, or a synthetic root if none.
+  LogScope get currentScope =>
+      Zone.current[_logScopeKey] as LogScope? ?? _fallbackScope;
+
+  static final _fallbackScope = LogScope.root('unknown');
+
+  /// Checks level, evaluates the factory eagerly, and appends the write
+  /// to the chain. Writer errors are swallowed - logging is best-effort.
+  void call(LogLevel level, LogEntryFactory factory) {
+    if (level.index < logLevel.index || _closed) return;
+    _latest = _latest.then((_) async {
+      try {
+        await _writer.log(await factory());
+      } catch (_) {}
+    });
+  }
+
+  /// Awaits in-flight writes without blocking further dispatches.
+  Future<void> flush() => _latest;
+
+  /// Awaits in-flight writes and blocks further dispatches.
+  Future<void> close() async {
+    _closed = true;
+    await flush();
+  }
+}
+
+/// Convenience methods for common log levels.
+extension LogConvenience on Log {
+  /// Logs [message] at [LogLevel.debug].
+  void debug(String message, {Map<String, Object?>? metadata}) => this(
+    LogLevel.debug,
+    () => LogEntry(
+      time: DateTime.now(),
+      level: LogLevel.debug,
+      message: message,
+      scope: currentScope,
+      metadata: metadata,
+    ),
+  );
+
+  /// Logs [message] at [LogLevel.info].
+  void info(String message, {Map<String, Object?>? metadata}) => this(
+    LogLevel.info,
+    () => LogEntry(
+      time: DateTime.now(),
+      level: LogLevel.info,
+      message: message,
+      scope: currentScope,
+      metadata: metadata,
+    ),
+  );
+
+  /// Logs [message] at [LogLevel.warning].
+  void warning(String message, {Map<String, Object?>? metadata}) => this(
+    LogLevel.warning,
+    () => LogEntry(
+      time: DateTime.now(),
+      level: LogLevel.warning,
+      message: message,
+      scope: currentScope,
+      metadata: metadata,
+    ),
+  );
+
+  /// Logs [message] at [LogLevel.error], optionally attaching an [error]
+  /// value and [stackTrace].
+  void error(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, Object?>? metadata,
+  }) => this(
+    LogLevel.error,
+    () => LogEntry(
+      time: DateTime.now(),
+      level: LogLevel.error,
+      message: message,
+      scope: currentScope,
+      error: error,
+      stackTrace: stackTrace,
+      metadata: metadata,
+    ),
+  );
+
+  /// Whether debug-level messages are currently forwarded to the writer.
+  /// Use to gate expensive message construction:
+  /// `if (log.isDebugEnabled) log.debug(formatBigObject(x));`.
+  bool get isDebugEnabled => logLevel.index <= LogLevel.debug.index;
+}
+
+/// Scope management: progress operations and manual scope control.
+extension LogScoping on Log {
+  /// Runs [runner] inside a new scope. The scope is automatically opened
+  /// before the runner and closed after it completes (or fails).
+  ///
+  /// Log calls inside the runner are automatically scoped via the Zone.
+  ///
+  /// Success signal:
+  /// - If [runner] throws, the scope closes with `success: false`.
+  /// - Else if [isSuccess] is provided, its return value is used.
+  /// - Else if [T] is `bool`, the returned value is used directly.
+  /// - Otherwise, the scope closes with `success: true`.
+  Future<T> progress<T>(
+    String label,
+    FutureOr<T> Function() runner, {
+    Map<String, Object?>? metadata,
+    bool Function(T result)? isSuccess,
+  }) async {
+    final scope = currentScope.child(
+      id: _newScopeId(label),
+      label: label,
+      metadata: metadata,
+    );
+    await _writer.openScope(scope);
+    final stopwatch = Stopwatch()..start();
+    try {
+      final result = await runZoned(
+        runner,
+        zoneValues: {_logScopeKey: scope},
+      );
+      await _writer.closeScope(
+        scope,
+        success: isSuccess?.call(result) ?? (result is bool ? result : true),
+        duration: stopwatch.elapsed,
+      );
+      return result;
+    } catch (e, st) {
+      await _writer.closeScope(
+        scope,
+        success: false,
+        duration: stopwatch.elapsed,
+        error: e,
+        stackTrace: st,
+      );
+      rethrow;
+    }
+  }
+}

--- a/packages/serverpod_logging/lib/src/log.dart
+++ b/packages/serverpod_logging/lib/src/log.dart
@@ -157,10 +157,7 @@ extension LogScoping on Log {
     await _writer.openScope(scope);
     final stopwatch = Stopwatch()..start();
     try {
-      final result = await runZoned(
-        runner,
-        zoneValues: {_logScopeKey: scope},
-      );
+      final result = await runZoned(runner, zoneValues: {_logScopeKey: scope});
       await _writer.closeScope(
         scope,
         success: isSuccess?.call(result) ?? (result is bool ? result : true),

--- a/packages/serverpod_logging/lib/src/log_types.dart
+++ b/packages/serverpod_logging/lib/src/log_types.dart
@@ -1,0 +1,178 @@
+/// Log severity level.
+enum LogLevel {
+  /// Fine-grained diagnostic information, normally disabled in production.
+  debug,
+
+  /// Informational messages describing normal operation.
+  info,
+
+  /// Recoverable issues worth flagging but not halting the flow.
+  warning,
+
+  /// Errors the caller is expected to handle or surface.
+  error,
+
+  /// Unrecoverable failures. Usually followed by process teardown.
+  fatal,
+}
+
+/// A scoped operation. Scopes form a tree - every scope has a parent except the
+/// root scope.
+///
+/// A scope begins with [LogWriter.openScope] and ends with
+/// [LogWriter.closeScope]. Log entries within the scope reference it via
+/// [LogEntry.scope].
+class LogScope {
+  /// Stable identifier for this scope. Unique within a process lifetime;
+  /// referenced by [LogEntry.scope] and by scope open/close events.
+  final String id;
+
+  /// Human-readable label describing the scoped operation.
+  final String label;
+
+  /// Wall-clock time at which the scope was opened.
+  final DateTime startTime;
+
+  /// Enclosing scope, or `null` if this is a root scope.
+  final LogScope? parent;
+
+  /// Optional scope-level structured metadata (arbitrary key/value pairs).
+  final Map<String, Object?>? metadata;
+
+  /// Creates a scope. Prefer [LogScope.root] or [child] over calling this
+  /// directly.
+  const LogScope({
+    required this.id,
+    required this.label,
+    required this.startTime,
+    this.parent,
+    this.metadata,
+  });
+
+  /// Creates a root scope for a process.
+  factory LogScope.root(String label) => LogScope(
+    id: 'root',
+    label: label,
+    startTime: DateTime.now(),
+  );
+
+  /// Creates a child scope under this scope.
+  LogScope child({
+    required String id,
+    required String label,
+    Map<String, Object?>? metadata,
+  }) => LogScope(
+    id: id,
+    label: label,
+    startTime: DateTime.now(),
+    parent: this,
+    metadata: metadata,
+  );
+}
+
+/// A single log entry. Always belongs to a [LogScope].
+class LogEntry {
+  /// Wall-clock time at which the entry was produced.
+  final DateTime time;
+
+  /// Severity of the entry.
+  final LogLevel level;
+
+  /// The log message.
+  final String message;
+
+  /// Scope the entry was emitted from.
+  final LogScope scope;
+
+  /// Optional error associated with this entry.
+  final Object? error;
+
+  /// Optional stack trace captured alongside [error].
+  final StackTrace? stackTrace;
+
+  /// Optional entry-level structured metadata.
+  final Map<String, Object?>? metadata;
+
+  /// Creates a log entry.
+  const LogEntry({
+    required this.time,
+    required this.level,
+    required this.message,
+    required this.scope,
+    this.error,
+    this.stackTrace,
+    this.metadata,
+  });
+}
+
+/// Transport layer for log output. Implementations decide where logs go
+/// (terminal, database, VM service, TUI, etc.).
+///
+/// Use [MultiLogWriter] to fan out to multiple writers.
+abstract class LogWriter {
+  /// Writes a single log entry.
+  Future<void> log(LogEntry entry);
+
+  /// Begins a scoped operation.
+  Future<void> openScope(LogScope scope);
+
+  /// Ends a scoped operation.
+  Future<void> closeScope(
+    LogScope scope, {
+    required bool success,
+    required Duration duration,
+    Object? error,
+    StackTrace? stackTrace,
+  });
+
+  /// Releases any resources held by the writer.
+  Future<void> close() async {}
+}
+
+/// A [LogWriter] that fans out to multiple child writers.
+class MultiLogWriter extends LogWriter {
+  final List<LogWriter> _writers;
+
+  /// Creates a [MultiLogWriter] that fans out to [_writers]. The list is
+  /// held by reference and may be mutated via [add] / [remove].
+  MultiLogWriter(this._writers);
+
+  /// Appends [writer] to the chain. Useful when a writer can only be
+  /// constructed after the chain has already been built (e.g. a writer
+  /// that needs a database session that doesn't exist yet at startup).
+  void add(LogWriter writer) => _writers.add(writer);
+
+  /// Removes [writer] from the chain, if present. Counterpart to [add];
+  /// used when the chain needs to be reconfigured after construction
+  /// (e.g. swapping a console writer once config has been loaded).
+  bool remove(LogWriter writer) => _writers.remove(writer);
+
+  @override
+  Future<void> log(LogEntry entry) => _writers.map((w) => w.log(entry)).wait;
+
+  @override
+  Future<void> openScope(LogScope scope) =>
+      _writers.map((w) => w.openScope(scope)).wait;
+
+  @override
+  Future<void> closeScope(
+    LogScope scope, {
+    required bool success,
+    required Duration duration,
+    Object? error,
+    StackTrace? stackTrace,
+  }) => _writers
+      .map(
+        (w) => w.closeScope(
+          scope,
+          success: success,
+          duration: duration,
+          error: error,
+          stackTrace: stackTrace,
+        ),
+      )
+      .wait;
+
+  @override
+  Future<void> close() => _writers.map((w) => w.close()).wait;
+}

--- a/packages/serverpod_logging/lib/src/log_types.dart
+++ b/packages/serverpod_logging/lib/src/log_types.dart
@@ -50,11 +50,8 @@ class LogScope {
   });
 
   /// Creates a root scope for a process.
-  factory LogScope.root(String label) => LogScope(
-    id: 'root',
-    label: label,
-    startTime: DateTime.now(),
-  );
+  factory LogScope.root(String label) =>
+      LogScope(id: 'root', label: label, startTime: DateTime.now());
 
   /// Creates a child scope under this scope.
   LogScope child({
@@ -131,21 +128,25 @@ abstract class LogWriter {
 
 /// A [LogWriter] that fans out to multiple child writers.
 class MultiLogWriter extends LogWriter {
-  final List<LogWriter> _writers;
+  List<LogWriter> _writers;
 
-  /// Creates a [MultiLogWriter] that fans out to [_writers]. The list is
-  /// held by reference and may be mutated via [add] / [remove].
-  MultiLogWriter(this._writers);
+  /// Creates a [MultiLogWriter] that fans out to [writers].
+  MultiLogWriter(List<LogWriter> writers) : _writers = List.of(writers);
 
   /// Appends [writer] to the chain. Useful when a writer can only be
   /// constructed after the chain has already been built (e.g. a writer
   /// that needs a database session that doesn't exist yet at startup).
-  void add(LogWriter writer) => _writers.add(writer);
+  void add(LogWriter writer) => [..._writers, writer];
 
   /// Removes [writer] from the chain, if present. Counterpart to [add];
   /// used when the chain needs to be reconfigured after construction
   /// (e.g. swapping a console writer once config has been loaded).
-  bool remove(LogWriter writer) => _writers.remove(writer);
+  bool remove(LogWriter writer) {
+    final copy = List.of(_writers);
+    final removed = copy.remove(writer);
+    _writers = copy;
+    return removed;
+  }
 
   @override
   Future<void> log(LogEntry entry) => _writers.map((w) => w.log(entry)).wait;

--- a/packages/serverpod_logging/lib/src/spinner_log_writer.dart
+++ b/packages/serverpod_logging/lib/src/spinner_log_writer.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'log_types.dart';
+
+const _clearLine = '\u001b[2K\r';
+const _brailleFrames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+
+/// Whether stdout is an interactive terminal.
+bool isInteractiveTerminal = stdout.hasTerminal;
+
+/// Format a duration for display in spinner/completion lines.
+String formatElapsed(Duration d) {
+  final ms = d.inMilliseconds;
+  if (ms < 100) return '${ms}ms';
+  return '${(ms / 1000).toStringAsFixed(1)}s';
+}
+
+/// State for a single in-progress scope with a braille spinner.
+class ActiveScope {
+  /// Tracks [scope] and starts a stopwatch for its elapsed-time display.
+  ActiveScope(this.scope) : stopwatch = Stopwatch()..start();
+
+  /// The scope being rendered.
+  final LogScope scope;
+
+  /// Measures how long the scope has been open; read by the spinner
+  /// formatter to display elapsed time next to the label.
+  final Stopwatch stopwatch;
+}
+
+/// A [LogWriter] base class that manages braille progress spinners.
+///
+/// When stdout is a terminal, [openScope]/[closeScope] animate a spinner
+/// on the last line. Log messages print above the spinner, which redraws
+/// after each line.
+///
+/// Subclasses override [writeLogLine] to format log output and
+/// [formatSpinner]/[formatScopeComplete] to customize spinner appearance.
+abstract class SpinnerLogWriter extends LogWriter {
+  /// Stack of currently-open scopes, innermost last. The innermost entry
+  /// drives the active spinner line.
+  final List<ActiveScope> scopeStack = [];
+  Timer? _timer;
+  int _frameIndex = 0;
+
+  /// Write a single log entry to the terminal. Called after the spinner
+  /// line has been cleared and before it is redrawn.
+  void writeLogLine(LogEntry entry);
+
+  /// Format the spinner text for the currently active scope.
+  /// Default uses green braille frames with gray elapsed time.
+  String formatSpinner(String frame, ActiveScope active) {
+    return '$frame ${active.scope.label}... (${formatElapsed(active.stopwatch.elapsed)})';
+  }
+
+  /// Format the scope completion line.
+  /// Default uses ✓/✗ with the label and elapsed time.
+  String formatScopeComplete(LogScope scope, bool success, Duration duration) {
+    final icon = success ? '\u2713' : '\u2717';
+    return '$icon ${scope.label} (${formatElapsed(duration)})';
+  }
+
+  /// Format the scope label for non-interactive (pipe) output.
+  String formatScopeStart(LogScope scope) => '${scope.label}...';
+
+  /// Format the scope completion for non-interactive output.
+  String formatScopeEnd(LogScope scope, bool success, Duration duration) {
+    final status = success ? 'done' : 'failed';
+    return '${scope.label} $status. (${formatElapsed(duration)})';
+  }
+
+  @override
+  Future<void> log(LogEntry entry) async {
+    _clearSpinnerLine();
+    writeLogLine(entry);
+    _drawSpinner();
+  }
+
+  @override
+  Future<void> openScope(LogScope scope) async {
+    if (isInteractiveTerminal) {
+      _clearSpinnerLine();
+      scopeStack.add(ActiveScope(scope));
+      _drawSpinner();
+      _startTimer();
+    } else {
+      stdout.writeln(formatScopeStart(scope));
+    }
+  }
+
+  @override
+  Future<void> closeScope(
+    LogScope scope, {
+    required bool success,
+    required Duration duration,
+    Object? error,
+    StackTrace? stackTrace,
+  }) async {
+    if (isInteractiveTerminal) {
+      _clearSpinnerLine();
+      scopeStack.removeWhere((s) => s.scope.id == scope.id);
+      if (scopeStack.isEmpty) _stopTimer();
+
+      stdout.writeln(formatScopeComplete(scope, success, duration));
+
+      _drawSpinner();
+    } else {
+      stdout.writeln(formatScopeEnd(scope, success, duration));
+    }
+  }
+
+  void _startTimer() {
+    if (_timer != null) return;
+    _timer = Timer.periodic(const Duration(milliseconds: 80), (_) {
+      _drawSpinner();
+    });
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _drawSpinner() {
+    if (scopeStack.isEmpty || !isInteractiveTerminal) return;
+    final active = scopeStack.last;
+    _frameIndex++;
+    final frame = _brailleFrames[_frameIndex % _brailleFrames.length];
+    stdout.write('$_clearLine${formatSpinner(frame, active)}');
+  }
+
+  void _clearSpinnerLine() {
+    if (isInteractiveTerminal && scopeStack.isNotEmpty) {
+      stdout.write(_clearLine);
+    }
+  }
+}

--- a/packages/serverpod_logging/lib/src/test_log_writer.dart
+++ b/packages/serverpod_logging/lib/src/test_log_writer.dart
@@ -1,0 +1,69 @@
+import 'package:meta/meta.dart';
+
+import 'log_types.dart';
+
+/// A completed scope record for test assertions.
+class ClosedScope {
+  /// Captures the arguments passed to [LogWriter.closeScope].
+  ClosedScope({
+    required this.scope,
+    required this.success,
+    required this.duration,
+    this.error,
+    this.stackTrace,
+  });
+
+  /// The scope that was closed.
+  final LogScope scope;
+
+  /// Whether the scope completed successfully.
+  final bool success;
+
+  /// How long the scope was open.
+  final Duration duration;
+
+  /// Optional error captured when the scope failed.
+  final Object? error;
+
+  /// Optional stack trace for [error].
+  final StackTrace? stackTrace;
+}
+
+/// A [LogWriter] that collects entries and scopes for test assertions.
+@visibleForTesting
+class TestLogWriter extends LogWriter {
+  /// Log entries written via [log], in call order.
+  final List<LogEntry> entries = [];
+
+  /// Scopes opened via [openScope], in call order.
+  final List<LogScope> openedScopes = [];
+
+  /// Scopes closed via [closeScope], in call order, with their close-time
+  /// success/error details.
+  final List<ClosedScope> closedScopes = [];
+
+  @override
+  Future<void> log(LogEntry entry) async => entries.add(entry);
+
+  @override
+  Future<void> openScope(LogScope scope) async => openedScopes.add(scope);
+
+  @override
+  Future<void> closeScope(
+    LogScope scope, {
+    required bool success,
+    required Duration duration,
+    Object? error,
+    StackTrace? stackTrace,
+  }) async {
+    closedScopes.add(
+      ClosedScope(
+        scope: scope,
+        success: success,
+        duration: duration,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+}

--- a/packages/serverpod_logging/lib/src/text_log_writer.dart
+++ b/packages/serverpod_logging/lib/src/text_log_writer.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'log_types.dart';
+import 'spinner_log_writer.dart';
+
+bool get _ansiSupported => isInteractiveTerminal && stdout.supportsAnsiEscapes;
+
+String _green(String text) => _ansiSupported ? '\x1B[92m$text\x1B[0m' : text;
+String _yellow(String text) => _ansiSupported ? '\x1B[93m$text\x1B[0m' : text;
+String _red(String text) => _ansiSupported ? '\x1B[91m$text\x1B[0m' : text;
+String _gray(String text) => _ansiSupported ? '\x1B[90m$text\x1B[0m' : text;
+String _cyan(String text) => _ansiSupported ? '\x1B[36m$text\x1B[0m' : text;
+
+/// A [SpinnerLogWriter] that writes formatted text to stdout/stderr.
+///
+/// Log messages are prefixed with the level (DEBUG, WARNING, ERROR).
+/// Errors and stack traces are written to stderr.
+class TextLogWriter extends SpinnerLogWriter {
+  @override
+  void writeLogLine(LogEntry entry) {
+    final prefix = switch (entry.level) {
+      LogLevel.debug => _gray('DEBUG: '),
+      LogLevel.info => '',
+      LogLevel.warning => _yellow('WARNING: '),
+      LogLevel.error || LogLevel.fatal => _red('ERROR: '),
+    };
+    final output = '$prefix${entry.message}';
+    if (entry.level.index >= LogLevel.error.index) {
+      stderr.writeln(output);
+      if (entry.error != null) stderr.writeln('${entry.error}');
+      if (entry.stackTrace != null) stderr.writeln('${entry.stackTrace}');
+    } else {
+      stdout.writeln(output);
+    }
+  }
+
+  @override
+  String formatSpinner(String frame, ActiveScope active) {
+    final elapsed = _gray('(${formatElapsed(active.stopwatch.elapsed)})');
+    return '${_cyan(frame)} ${active.scope.label}... $elapsed';
+  }
+
+  @override
+  String formatScopeComplete(LogScope scope, bool success, Duration duration) {
+    final elapsed = _gray('(${formatElapsed(duration)})');
+    final icon = success ? _green('\u2713') : _red('\u2717');
+    return '$icon ${scope.label} $elapsed';
+  }
+}

--- a/packages/serverpod_logging/pubspec.yaml
+++ b/packages/serverpod_logging/pubspec.yaml
@@ -1,0 +1,12 @@
+name: serverpod_logging
+description: Shared serverpod logging utilities.
+version: 0.0.1
+repository: https://github.com/serverpod/serverpod
+homepage: https://serverpod.dev
+issue_tracker: https://github.com/serverpod/serverpod/issues
+
+environment:
+  sdk: ^3.10.3
+
+dev_dependencies:
+  test: ^1.25.6

--- a/packages/serverpod_logging/pubspec.yaml
+++ b/packages/serverpod_logging/pubspec.yaml
@@ -8,5 +8,9 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: ^3.10.3
 
+dependencies: 
+  meta: ^1.15.0
+
 dev_dependencies:
+  serverpod_lints: '>=2.7.0'
   test: ^1.25.6

--- a/packages/serverpod_logging/test/log_progress_test.dart
+++ b/packages/serverpod_logging/test/log_progress_test.dart
@@ -1,0 +1,96 @@
+import 'package:serverpod_logging/serverpod_logging.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given Log.progress with a runner that returns bool', () {
+    late TestLogWriter writer;
+    late Log log;
+
+    setUp(() {
+      writer = TestLogWriter();
+      log = Log(writer);
+    });
+
+    test('when the runner returns true, '
+        'then the scope closes with success true', () async {
+      await log.progress('op', () async => true);
+
+      expect(writer.closedScopes, hasLength(1));
+      expect(writer.closedScopes.first.success, isTrue);
+    });
+
+    test('when the runner returns false, '
+        'then the scope closes with success false', () async {
+      await log.progress('op', () async => false);
+
+      expect(writer.closedScopes, hasLength(1));
+      expect(writer.closedScopes.first.success, isFalse);
+    });
+  });
+
+  group('Given Log.progress with a runner that returns a non-bool value', () {
+    late TestLogWriter writer;
+    late Log log;
+
+    setUp(() {
+      writer = TestLogWriter();
+      log = Log(writer);
+    });
+
+    test('when no isSuccess is provided, '
+        'then the scope closes with success true', () async {
+      await log.progress<String>('op', () async => 'ok');
+
+      expect(writer.closedScopes.first.success, isTrue);
+    });
+
+    test('when isSuccess is provided, '
+        'then the scope uses its verdict', () async {
+      await log.progress<String>(
+        'op',
+        () async => 'fail',
+        isSuccess: (r) => r == 'ok',
+      );
+
+      expect(writer.closedScopes.first.success, isFalse);
+    });
+  });
+
+  group('Given Log.progress with a runner that throws', () {
+    late TestLogWriter writer;
+    late Log log;
+
+    setUp(() {
+      writer = TestLogWriter();
+      log = Log(writer);
+    });
+
+    test('when the runner throws, '
+        'then the scope closes with success false and rethrows', () async {
+      await expectLater(
+        log.progress<bool>('op', () async => throw StateError('boom')),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(writer.closedScopes.first.success, isFalse);
+      expect(writer.closedScopes.first.error, isA<StateError>());
+    });
+
+    test(
+      'when isSuccess would return true but runner throws, '
+      'then throw takes precedence and scope closes with success false',
+      () async {
+        await expectLater(
+          log.progress<bool>(
+            'op',
+            () async => throw StateError('boom'),
+            isSuccess: (_) => true,
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(writer.closedScopes.first.success, isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
This PR adds a `serverpod_logging` package that contains tools for bridging logging between Serverpod framework and CLI tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the serverpod_logging package: global logger, severity levels, scoped progress tracking, interactive spinners, and text output; test helpers for assertions.

* **Documentation**
  * Added package README and initial CHANGELOG (v0.0.1).

* **Tests**
  * Added tests covering scoped progress behavior and error handling.

* **Chores**
  * Added package manifest, analysis config, and .gitignore for the new package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->