### PR TITLE
feat: Add support for progress stream to serverpod_logging

### DIFF
--- a/packages/serverpod_logging/lib/src/log.dart
+++ b/packages/serverpod_logging/lib/src/log.dart
@@ -5,6 +5,9 @@ import 'log_types.dart';
 /// Symbol used to store the current [LogScope] in Zone values.
 const Symbol _logScopeKey = #_logScope;
 
+/// Symbol used to store the current [LogWriter] in Zone values.
+const Symbol _logWriterKey = #_logWriter;
+
 final _stopwatch = Stopwatch()..start();
 int _scopeCounter = 0;
 String _newScopeId(String label) =>
@@ -39,6 +42,9 @@ class Log {
   /// Creates a [Log] that forwards to [_writer]. Messages below [logLevel]
   /// are dropped before the [LogEntryFactory] runs.
   Log(this._writer, {this.logLevel = LogLevel.info});
+
+  /// The current writer from the Zone.
+  LogWriter? get currentWriter => Zone.current[_logWriterKey] as LogWriter?;
 
   /// The current scope from the Zone, or a synthetic root if none.
   LogScope get currentScope =>
@@ -145,19 +151,46 @@ extension LogScoping on Log {
   /// - Otherwise, the scope closes with `success: true`.
   Future<T> progress<T>(
     String label,
-    FutureOr<T> Function() runner, {
+    Future<T> Function() runner, {
     Map<String, Object?>? metadata,
     bool Function(T result)? isSuccess,
   }) async {
+    return await progressStream(
+      label,
+      Stream.fromFuture(runner()),
+      isSuccess: isSuccess,
+      metadata: metadata,
+    );
+  }
+
+  /// Opens a new scope, consumes [stream] updating the scope label on each
+  /// event via [toMessage], then closes the scope.
+  ///
+  /// Success signal:
+  /// - If [stream] emits an error event, the scope closes with `success: false`.
+  /// - Else if [isSuccess] is provided, its return value is used.
+  /// - Else if [T] is `bool`, the returned value is used directly.
+  /// - Otherwise, the scope closes with `success: true`.
+  Future<T> progressStream<T>(
+    String initialMessage,
+    Stream<T> stream, {
+    String Function(T)? toMessage,
+    bool Function(T)? isSuccess,
+    Map<String, Object?>? metadata,
+  }) async {
     final scope = currentScope.child(
-      id: _newScopeId(label),
-      label: label,
+      id: _newScopeId(initialMessage),
+      label: initialMessage,
       metadata: metadata,
     );
     await _writer.openScope(scope);
     final stopwatch = Stopwatch()..start();
     try {
-      final result = await runZoned(runner, zoneValues: {_logScopeKey: scope});
+      final result = await runZoned(
+        () => _consumeStream(stream, toMessage: toMessage),
+        zoneValues: {_logScopeKey: scope, _logWriterKey: _writer},
+      );
+
       await _writer.closeScope(
         scope,
         success: isSuccess?.call(result) ?? (result is bool ? result : true),
@@ -174,5 +207,27 @@ extension LogScoping on Log {
       );
       rethrow;
     }
+  }
+
+  /// Iterates [stream] to completion, updating the current scope's label
+  /// with [toMessage] on each event. Returns the last event, or throws a
+  /// [StateError] if the stream is empty.
+  Future<T> _consumeStream<T>(
+    Stream<T> stream, {
+    String Function(T)? toMessage,
+  }) async {
+    bool hasEvent = false;
+    T? finalEvent;
+    await for (final event in stream) {
+      hasEvent = true;
+      finalEvent = event;
+      final message = toMessage?.call(event) ?? event.toString();
+      await currentWriter?.updateScope(currentScope.copyWith(label: message));
+    }
+    if (!hasEvent || finalEvent is! T) {
+      throw StateError('No events in stream');
+    }
+
+    return finalEvent;
   }
 }

--- a/packages/serverpod_logging/lib/src/log_types.dart
+++ b/packages/serverpod_logging/lib/src/log_types.dart
@@ -65,6 +65,17 @@ class LogScope {
     parent: this,
     metadata: metadata,
   );
+
+  /// Creates a copy of this [LogScope] with an optionally replaced [label].
+  LogScope copyWith({String? label}) {
+    return LogScope(
+      id: id,
+      label: label ?? this.label,
+      startTime: startTime,
+      parent: parent,
+      metadata: metadata,
+    );
+  }
 }
 
 /// A single log entry. Always belongs to a [LogScope].
@@ -113,6 +124,9 @@ abstract class LogWriter {
   /// Begins a scoped operation.
   Future<void> openScope(LogScope scope);
 
+  /// Updates a scoped operation.
+  Future<void> updateScope(LogScope scope);
+
   /// Ends a scoped operation.
   Future<void> closeScope(
     LogScope scope, {
@@ -154,6 +168,10 @@ class MultiLogWriter extends LogWriter {
   @override
   Future<void> openScope(LogScope scope) =>
       _writers.map((w) => w.openScope(scope)).wait;
+
+  @override
+  Future<void> updateScope(LogScope scope) =>
+      _writers.map((w) => w.updateScope(scope)).wait;
 
   @override
   Future<void> closeScope(

--- a/packages/serverpod_logging/lib/src/serverpod_cli_logger.dart
+++ b/packages/serverpod_logging/lib/src/serverpod_cli_logger.dart
@@ -1,0 +1,181 @@
+import 'dart:io';
+
+import 'package:cli_tools/cli_tools.dart' as cli;
+
+import 'log.dart';
+import 'log_types.dart';
+import 'std_out_log_writer.dart';
+
+// ---------------------------------------------------------------------------
+// ServerpodCliLogger - bridges cli_tools.Logger to the serverpod_logging Log
+// ---------------------------------------------------------------------------
+
+/// A [cli.Logger] that delegates to a serverpod_logging [Log].
+///
+/// This bridges the cli_tools logging interface with the serverpod_logging
+/// log writer architecture, allowing multi-backend logging (terminal, TUI,
+/// file, etc.) via [LogWriter] and [MultiLogWriter].
+///
+/// [cli.LogType] is preserved by stashing it in [LogEntry.metadata]
+/// under [logTypeKey], so writers like [StdOutLogWriter] can format
+/// output accordingly.
+class ServerpodCliLogger extends cli.Logger {
+  final Log _log;
+  final LogWriter _writer;
+
+  ServerpodCliLogger(LogWriter writer, {LogLevel logLevel = LogLevel.info})
+    : _writer = writer,
+      _log = Log(writer, logLevel: logLevel),
+      super(_mapLevel(logLevel));
+
+  /// Releases any resources held by the underlying writer.
+  Future<void> close() async {
+    await _log.close();
+    await _writer.close();
+  }
+
+  @override
+  set logLevel(cli.LogLevel level) {
+    super.logLevel = level;
+    if (level == cli.LogLevel.nothing) return;
+    _log.logLevel = _mapLogLevel(level);
+  }
+
+  @override
+  int? get wrapTextColumn => stdout.hasTerminal ? stdout.terminalColumns : null;
+
+  @override
+  void debug(
+    String message, {
+    bool newParagraph = false,
+    cli.LogType type = cli.TextLogType.normal,
+  }) {
+    _call(LogLevel.debug, message, type: type);
+  }
+
+  @override
+  void info(
+    String message, {
+    bool newParagraph = false,
+    cli.LogType type = cli.TextLogType.normal,
+  }) {
+    _call(LogLevel.info, message, type: type);
+  }
+
+  @override
+  void warning(
+    String message, {
+    bool newParagraph = false,
+    cli.LogType type = cli.TextLogType.normal,
+  }) {
+    _call(LogLevel.warning, message, type: type);
+  }
+
+  @override
+  void error(
+    String message, {
+    bool newParagraph = false,
+    StackTrace? stackTrace,
+    cli.LogType type = cli.TextLogType.normal,
+  }) {
+    final msg = stackTrace != null
+        ? '$message\n${stackTrace.toString()}'
+        : message;
+    _call(LogLevel.error, msg, type: type);
+  }
+
+  @override
+  void log(
+    String message,
+    cli.LogLevel level, {
+    bool newParagraph = false,
+    cli.LogType type = cli.TextLogType.normal,
+  }) {
+    _call(_mapLogLevel(level), message, type: type);
+  }
+
+  @override
+  void write(
+    String message,
+    cli.LogLevel logLevel, {
+    bool newParagraph = false,
+    bool newLine = true,
+  }) {
+    _call(_mapLogLevel(logLevel), message);
+  }
+
+  @override
+  Future<bool> progress(
+    String message,
+    Future<bool> Function() runner, {
+    bool newParagraph = false,
+    String? successMessage,
+  }) {
+    if (_silent) return runner();
+    return _log.progress(message, runner);
+  }
+
+  @override
+  Future<T> progressStream<T>(
+    String initialMessage,
+    Stream<T> stream, {
+    String Function(T)? toMessage,
+    bool Function(T)? isSuccess,
+    bool newParagraph = false,
+  }) async {
+    if (_silent) return stream.last;
+    return _log.progressStream(
+      initialMessage,
+      stream,
+      toMessage: toMessage,
+      isSuccess: isSuccess,
+    );
+  }
+
+  @override
+  Future<void> flush() => _log.flush();
+
+  void _call(LogLevel level, String message, {cli.LogType? type}) {
+    if (_silent) return;
+    _log(
+      level,
+      () => LogEntry(
+        time: DateTime.now(),
+        level: level,
+        message: message,
+        scope: _log.currentScope,
+        metadata: type != null ? {logTypeKey: type} : null,
+      ),
+    );
+  }
+
+  // serverpod_logging LogLevel has no "nothing" sentinel - its lowest-passing
+  // level is fatal, and the filter check is strict-`<` so fatal still leaks
+  // through. Progress / scope events bypass logLevel entirely. So when the
+  // caller sets cli.LogLevel.nothing we gate at the bridge instead of mapping
+  // through to _log.logLevel.
+  bool get _silent => super.logLevel == cli.LogLevel.nothing;
+
+  static cli.LogLevel _mapLevel(LogLevel level) => switch (level) {
+    LogLevel.debug => cli.LogLevel.debug,
+    LogLevel.info => cli.LogLevel.info,
+    LogLevel.warning => cli.LogLevel.warning,
+    LogLevel.error || LogLevel.fatal => cli.LogLevel.error,
+  };
+
+  static LogLevel _mapLogLevel(cli.LogLevel level) => switch (level) {
+    cli.LogLevel.debug => LogLevel.debug,
+    cli.LogLevel.info => LogLevel.info,
+    cli.LogLevel.warning => LogLevel.warning,
+    cli.LogLevel.error => LogLevel.error,
+    // The setter early-returns before reaching here, so this branch only
+    // fires from log() / write() being called with nothing as a message
+    // level - which is a programmer error worth surfacing.
+    cli.LogLevel.nothing => throw ArgumentError.value(
+      level,
+      'level',
+      'cli.LogLevel.nothing is a filter sentinel; it cannot be used as a '
+          'message level',
+    ),
+  };
+}

--- a/packages/serverpod_logging/lib/src/spinner_log_writer.dart
+++ b/packages/serverpod_logging/lib/src/spinner_log_writer.dart
@@ -18,8 +18,12 @@ String formatElapsed(Duration d) {
 
 /// State for a single in-progress scope with a braille spinner.
 class ActiveScope {
+  ActiveScope._(this.scope, this.stopwatch);
+
   /// Tracks [scope] and starts a stopwatch for its elapsed-time display.
-  ActiveScope(this.scope) : stopwatch = Stopwatch()..start();
+  factory ActiveScope(LogScope scope) {
+    return ActiveScope._(scope, Stopwatch()..start());
+  }
 
   /// The scope being rendered.
   final LogScope scope;
@@ -27,6 +31,12 @@ class ActiveScope {
   /// Measures how long the scope has been open; read by the spinner
   /// formatter to display elapsed time next to the label.
   final Stopwatch stopwatch;
+
+  /// Creates a copy of this [ActiveScope] with an optionally replaced
+  /// [scope].
+  ActiveScope copyWith({LogScope? scope}) {
+    return ActiveScope._(scope ?? this.scope, stopwatch);
+  }
 }
 
 /// A [LogWriter] base class that manages braille progress spinners.
@@ -84,6 +94,20 @@ abstract class SpinnerLogWriter extends LogWriter {
       scopeStack.add(ActiveScope(scope));
       _drawSpinner();
       _startTimer();
+    } else {
+      stdout.writeln(formatScopeStart(scope));
+    }
+  }
+
+  @override
+  Future<void> updateScope(LogScope scope) async {
+    if (isInteractiveTerminal) {
+      final index = scopeStack.indexWhere((e) => e.scope.id == scope.id);
+      if (index != -1) {
+        final updatedScope = scopeStack[index].copyWith(scope: scope);
+        scopeStack[index] = updatedScope;
+        _drawSpinner();
+      }
     } else {
       stdout.writeln(formatScopeStart(scope));
     }

--- a/packages/serverpod_logging/lib/src/std_out_log_writer.dart
+++ b/packages/serverpod_logging/lib/src/std_out_log_writer.dart
@@ -1,0 +1,58 @@
+import 'package:cli_tools/cli_tools.dart' as cli;
+
+import '../serverpod_logging.dart';
+
+/// Metadata key used to pass [cli.LogType] through [LogEntry.metadata].
+const logTypeKey = 'serverpod:logType';
+
+/// A [SpinnerLogWriter] that delegates log formatting to a cli_tools
+/// [cli.StdOutLogger] for [cli.LogType]-aware output (bullets, headers,
+/// boxes, etc.).
+///
+/// Spinner animation is handled by the [SpinnerLogWriter] base class.
+///
+/// [cli.LogType] is read from [LogEntry.metadata] using [logTypeKey].
+class StdOutLogWriter extends SpinnerLogWriter {
+  final cli.StdOutLogger _logger;
+
+  StdOutLogWriter({
+    Map<String, String>? replacements,
+  }) : _logger = cli.StdOutLogger(
+         // Accept all levels - filtering is done by Log, not the writer.
+         cli.LogLevel.debug,
+         replacements: replacements,
+       );
+
+  @override
+  void writeLogLine(LogEntry entry) {
+    final cliLevel = _mapLevel(entry.level);
+    final type =
+        entry.metadata?[logTypeKey] as cli.LogType? ?? cli.TextLogType.normal;
+    _logger.log(entry.message, cliLevel, type: type);
+  }
+
+  @override
+  String formatSpinner(String frame, ActiveScope active) {
+    final elapsed = cli.AnsiStyle.darkGray.wrap(
+      '(${formatElapsed(active.stopwatch.elapsed)})',
+    );
+    return '${cli.AnsiStyle.lightGreen.wrap(frame)} '
+        '${active.scope.label}... $elapsed';
+  }
+
+  @override
+  String formatScopeComplete(LogScope scope, bool success, Duration duration) {
+    final elapsed = cli.AnsiStyle.darkGray.wrap('(${formatElapsed(duration)})');
+    final icon = success
+        ? cli.AnsiStyle.lightGreen.wrap('\u2713')
+        : cli.AnsiStyle.red.wrap('\u2717');
+    return '$icon ${scope.label} $elapsed';
+  }
+
+  static cli.LogLevel _mapLevel(LogLevel level) => switch (level) {
+    LogLevel.debug => cli.LogLevel.debug,
+    LogLevel.info => cli.LogLevel.info,
+    LogLevel.warning => cli.LogLevel.warning,
+    LogLevel.error || LogLevel.fatal => cli.LogLevel.error,
+  };
+}

--- a/packages/serverpod_logging/lib/src/test_log_writer.dart
+++ b/packages/serverpod_logging/lib/src/test_log_writer.dart
@@ -38,6 +38,9 @@ class TestLogWriter extends LogWriter {
   /// Scopes opened via [openScope], in call order.
   final List<LogScope> openedScopes = [];
 
+  /// Scopes updated via [updateScope], in call order.
+  final List<LogScope> updatedScopes = [];
+
   /// Scopes closed via [closeScope], in call order, with their close-time
   /// success/error details.
   final List<ClosedScope> closedScopes = [];
@@ -47,6 +50,9 @@ class TestLogWriter extends LogWriter {
 
   @override
   Future<void> openScope(LogScope scope) async => openedScopes.add(scope);
+
+  @override
+  Future<void> updateScope(LogScope scope) async => updatedScopes.add(scope);
 
   @override
   Future<void> closeScope(

--- a/packages/serverpod_logging/pubspec.yaml
+++ b/packages/serverpod_logging/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ^3.10.3
 
 dependencies: 
+  cli_tools: ^0.13.1
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/serverpod_logging/test/progress_test.dart
+++ b/packages/serverpod_logging/test/progress_test.dart
@@ -1,0 +1,201 @@
+import 'package:serverpod_logging/serverpod_logging.dart';
+import 'package:test/test.dart';
+
+import 'test_utils/io_helper.dart';
+
+void main() {
+  group('Given a Log with TextLogWriter and info log level', () {
+    final log = Log(TextLogWriter(), logLevel: LogLevel.info);
+
+    group('when calling progress', () {
+      test(
+        'when runner completes successfully '
+        'then runner result is returned and progress is marked successful',
+        () async {
+          bool? result;
+
+          final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+            result = await log.progress('Working', () async => true);
+          });
+
+          expect(result, isTrue);
+          expect(stdout.output, contains('Working'));
+          expect(stdout.output, contains('✓'));
+          expect(stderr.output, isEmpty);
+        },
+      );
+
+      test(
+        'when runner completes unsuccessfully '
+        'then runner result is returned and progress is marked unsuccessful',
+        () async {
+          bool? result;
+
+          final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+            result = await log.progress('Working', () async => false);
+          });
+
+          expect(result, isFalse);
+          expect(stdout.output, contains('Working'));
+          expect(stdout.output, contains('✗'));
+          expect(stderr.output, isEmpty);
+        },
+      );
+
+      test(
+        'when runner throws an exception '
+        'then progress is marked failed and the exception is rethrown',
+        () async {
+          final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+            await expectLater(
+              log.progress('Working', () async => throw Exception('failed')),
+              throwsA(isA<Exception>()),
+            );
+          });
+
+          expect(stdout.output, contains('Working'));
+          expect(stdout.output, contains('✗'));
+          expect(stderr.output, isEmpty);
+        },
+      );
+    });
+
+    group('when calling progressStream', () {
+      test('when stream has no events '
+          'then StateError is thrown and progress is marked failed', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await expectLater(
+            log.progressStream<int>('Starting', const Stream<int>.empty()),
+            throwsA(
+              isA<StateError>().having(
+                (final e) => e.message,
+                'message',
+                'No events in stream',
+              ),
+            ),
+          );
+        });
+
+        expect(stdout.output, contains('Starting'));
+        expect(stdout.output, contains('✗'));
+        expect(stderr.output, isEmpty);
+      });
+
+      test(
+        'when stream has a single event '
+        'then the event is returned and progress is marked successful',
+        () async {
+          int? result;
+
+          final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+            result = await log.progressStream('Starting', Stream.value(42));
+          });
+
+          expect(result, 42);
+          expect(stdout.output, contains('Starting'));
+          expect(stdout.output, contains('42'));
+          expect(stdout.output, contains('✓'));
+          expect(stderr.output, isEmpty);
+        },
+      );
+
+      test(
+        'when stream has several events '
+        'then each event updates the message and the last event is returned',
+        () async {
+          int? result;
+
+          final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+            result = await log.progressStream(
+              'Starting',
+              Stream.fromIterable([1, 2, 3]),
+              toMessage: (final step) => 'Step $step',
+            );
+          });
+
+          expect(result, 3);
+          expect(stdout.output, contains('Starting'));
+          expect(stdout.output, contains('Step 1'));
+          expect(stdout.output, contains('Step 2'));
+          expect(stdout.output, contains('Step 3'));
+          expect(stdout.output, contains('✓'));
+          expect(stderr.output, isEmpty);
+        },
+      );
+
+      test('when stream completes successfully '
+          'then progress is marked successful', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await log.progressStream(
+            'Deploying',
+            Stream.fromIterable(['build', 'deploy']),
+            toMessage: (final phase) => phase,
+          );
+        });
+
+        expect(stdout.output, contains('Deploying'));
+        expect(stdout.output, contains('deploy'));
+        expect(stdout.output, contains('✓'));
+        expect(stdout.output, isNot(contains('✗')));
+      });
+
+      test('when stream completes and result is successful '
+          'then progress is marked successful', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await log.progressStream(
+            'Deploying',
+            Stream.fromIterable(['build', 'deploy']),
+            toMessage: (final phase) => phase,
+            isSuccess: (final phase) => phase == 'deploy',
+          );
+        });
+
+        expect(stdout.output, contains('Deploying'));
+        expect(stdout.output, contains('deploy'));
+        expect(stdout.output, contains('✓'));
+        expect(stdout.output, isNot(contains('✗')));
+      });
+
+      test('when stream completes but result is not successful '
+          'then progress is marked unsuccessful', () async {
+        final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+          await log.progressStream(
+            'Deploying',
+            Stream.fromIterable(['build', 'deploy']),
+            toMessage: (final phase) => phase,
+            isSuccess: (final phase) => phase == 'some-other-phase',
+          );
+        });
+
+        expect(stdout.output, contains('Deploying'));
+        expect(stdout.output, contains('deploy'));
+        expect(stdout.output, contains('✗'));
+        expect(stdout.output, isNot(contains('✓')));
+      });
+
+      test(
+        'when stream throws an exception '
+        'then progress is marked failed and the exception is rethrown',
+        () async {
+          Stream<int> failingStream() async* {
+            yield 1;
+            throw Exception('stream failed');
+          }
+
+          final (:stdout, :stderr, :stdin) = await collectOutput(() async {
+            await expectLater(
+              log.progressStream('Starting', failingStream()),
+              throwsA(isA<Exception>()),
+            );
+          });
+
+          expect(stdout.output, contains('Starting'));
+          expect(stdout.output, contains('1'));
+          expect(stdout.output, contains('✗'));
+          expect(stdout.output, isNot(contains('✓')));
+          expect(stderr.output, isEmpty);
+        },
+      );
+    });
+  });
+}

--- a/packages/serverpod_logging/test/test_utils/io_helper.dart
+++ b/packages/serverpod_logging/test/test_utils/io_helper.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'mock_stdin.dart';
+import 'mock_stdout.dart';
+
+Future<({MockStdout stdout, MockStdout stderr, MockStdin stdin})>
+    collectOutput<T>(
+  final FutureOr<T> Function() runner, {
+  final List<String> stdinLines = const [],
+  final List<int> keyInputs = const [],
+}) async {
+  final standardOut = MockStdout();
+  final standardError = MockStdout();
+  final standardIn = MockStdin(textInputs: stdinLines, keyInputs: keyInputs);
+
+  await IOOverrides.runZoned(
+    () async {
+      return await runner();
+    },
+    stdout: () => standardOut,
+    stderr: () => standardError,
+    stdin: () => standardIn,
+  );
+
+  return (stdout: standardOut, stderr: standardError, stdin: standardIn);
+}

--- a/packages/serverpod_logging/test/test_utils/io_helper.dart
+++ b/packages/serverpod_logging/test/test_utils/io_helper.dart
@@ -5,7 +5,7 @@ import 'mock_stdin.dart';
 import 'mock_stdout.dart';
 
 Future<({MockStdout stdout, MockStdout stderr, MockStdin stdin})>
-    collectOutput<T>(
+collectOutput<T>(
   final FutureOr<T> Function() runner, {
   final List<String> stdinLines = const [],
   final List<int> keyInputs = const [],

--- a/packages/serverpod_logging/test/test_utils/mock_stdin.dart
+++ b/packages/serverpod_logging/test/test_utils/mock_stdin.dart
@@ -1,0 +1,260 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+class MockStdin implements Stdin {
+  final List<String> _textInputs;
+  final List<int> _keyInputs;
+  int _currentTextIndex = 0;
+  int _currentByteIndex = 0;
+
+  MockStdin({
+    final List<String> textInputs = const [],
+    final List<int> keyInputs = const [],
+  })  : _textInputs = textInputs,
+        _keyInputs = keyInputs;
+
+  @override
+  bool get echoMode => false;
+
+  @override
+  set echoMode(final bool value) {}
+
+  @override
+  bool get lineMode => false;
+
+  @override
+  Future<bool> any(final bool Function(List<int> element) test) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> asBroadcastStream({
+    final void Function(StreamSubscription<List<int>> subscription)? onListen,
+    final void Function(StreamSubscription<List<int>> subscription)? onCancel,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<E> asyncExpand<E>(final Stream<E>? Function(List<int> event) convert) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<E> asyncMap<E>(final FutureOr<E> Function(List<int> event) convert) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<R> cast<R>() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> contains(final Object? needle) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> distinct([
+    final bool Function(List<int> previous, List<int> next)? equals,
+  ]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<E> drain<E>([final E? futureValue]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<int>> elementAt(final int index) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> every(final bool Function(List<int> element) test) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<S> expand<S>(final Iterable<S> Function(List<int> element) convert) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<int>> get first => throw UnimplementedError();
+
+  @override
+  Future<List<int>> firstWhere(
+    final bool Function(List<int> element) test, {
+    final List<int> Function()? orElse,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<S> fold<S>(
+    final S initialValue,
+    final S Function(S previous, List<int> element) combine,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> forEach(final void Function(List<int> element) action) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> handleError(
+    final Function onError, {
+    final bool Function(dynamic error)? test,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool get hasTerminal => throw UnimplementedError();
+
+  @override
+  bool get isBroadcast => throw UnimplementedError();
+
+  @override
+  Future<bool> get isEmpty => throw UnimplementedError();
+
+  @override
+  Future<String> join([final String separator = '']) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<int>> get last => throw UnimplementedError();
+
+  @override
+  Future<List<int>> lastWhere(
+    final bool Function(List<int> element) test, {
+    final List<int> Function()? orElse,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<int> get length => throw UnimplementedError();
+
+  @override
+  StreamSubscription<List<int>> listen(
+    final void Function(List<int> event)? onData, {
+    final Function? onError,
+    final void Function()? onDone,
+    final bool? cancelOnError,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<S> map<S>(final S Function(List<int> event) convert) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future pipe(final StreamConsumer<List<int>> streamConsumer) {
+    throw UnimplementedError();
+  }
+
+  @override
+  int readByteSync() {
+    if (_currentByteIndex < _keyInputs.length) {
+      return _keyInputs[_currentByteIndex++];
+    }
+    return -1; // Simulate end of input
+  }
+
+  @override
+  String? readLineSync({
+    final Encoding encoding = systemEncoding,
+    final bool retainNewlines = false,
+  }) {
+    if (_currentTextIndex < _textInputs.length) {
+      return _textInputs[_currentTextIndex++];
+    }
+    return null; // Simulate end of input
+  }
+
+  @override
+  Future<List<int>> reduce(
+    final List<int> Function(List<int> previous, List<int> element) combine,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<int>> get single => throw UnimplementedError();
+
+  @override
+  Future<List<int>> singleWhere(
+    final bool Function(List<int> element) test, {
+    final List<int> Function()? orElse,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> skip(final int count) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> skipWhile(final bool Function(List<int> element) test) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool get supportsAnsiEscapes => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> take(final int count) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> takeWhile(final bool Function(List<int> element) test) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> timeout(
+    final Duration timeLimit, {
+    final void Function(EventSink<List<int>> sink)? onTimeout,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<List<int>>> toList() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Set<List<int>>> toSet() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<S> transform<S>(
+      final StreamTransformer<List<int>, S> streamTransformer) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> where(final bool Function(List<int> event) test) {
+    throw UnimplementedError();
+  }
+
+  @override
+  set lineMode(final bool lineMode) {}
+
+  @override
+  bool echoNewlineMode = false;
+}

--- a/packages/serverpod_logging/test/test_utils/mock_stdin.dart
+++ b/packages/serverpod_logging/test/test_utils/mock_stdin.dart
@@ -11,8 +11,8 @@ class MockStdin implements Stdin {
   MockStdin({
     final List<String> textInputs = const [],
     final List<int> keyInputs = const [],
-  })  : _textInputs = textInputs,
-        _keyInputs = keyInputs;
+  }) : _textInputs = textInputs,
+       _keyInputs = keyInputs;
 
   @override
   bool get echoMode => false;
@@ -243,7 +243,8 @@ class MockStdin implements Stdin {
 
   @override
   Stream<S> transform<S>(
-      final StreamTransformer<List<int>, S> streamTransformer) {
+    final StreamTransformer<List<int>, S> streamTransformer,
+  ) {
     throw UnimplementedError();
   }
 

--- a/packages/serverpod_logging/test/test_utils/mock_stdout.dart
+++ b/packages/serverpod_logging/test/test_utils/mock_stdout.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+class MockStdout implements Stdout {
+  final _buffer = StringBuffer();
+
+  @override
+  Encoding encoding = utf8;
+
+  @override
+  String lineTerminator = '\n';
+
+  String get output => _buffer.toString();
+
+  @override
+  void add(final List<int> data) {
+    _buffer.write(utf8.decode(data));
+  }
+
+  @override
+  void addError(final Object error, [final StackTrace? stackTrace]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future addStream(final Stream<List<int>> stream) {
+    return stream.forEach(add);
+  }
+
+  @override
+  Future close() {
+    return Future.value();
+  }
+
+  @override
+  Future get done => Future.value();
+
+  @override
+  Future flush() {
+    return Future.value();
+  }
+
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  IOSink get nonBlocking => throw UnimplementedError();
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  int get terminalColumns => 80;
+
+  @override
+  int get terminalLines => 24;
+
+  @override
+  void write(final Object? object) {
+    if (object.toString() == '\x1B[2J\x1B[H') {
+      _buffer.clear();
+    } else {
+      _buffer.write(object);
+    }
+  }
+
+  @override
+  void writeAll(final Iterable objects, [final String sep = '']) {
+    _buffer.writeAll(objects, sep);
+  }
+
+  @override
+  void writeCharCode(final int charCode) {
+    _buffer.writeCharCode(charCode);
+  }
+
+  @override
+  void writeln([final Object? object = '']) {
+    _buffer.writeln(object);
+  }
+}


### PR DESCRIPTION
`Log` gains a `progressStream` method to mirror the `Logger` interface from `cli_tools`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stream-based progress logging with support for per-event message updates and custom success criteria
  * Added ability to update scope labels and metadata during active logging operations
  * Added Zone-based writer context for improved async logging support

* **Changes**
  * Progress operation runners now strictly require `Future` return types (breaking change)

* **Tests**
  * Added comprehensive test coverage for progress logging scenarios including stream handling and scope updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->